### PR TITLE
skip non existing dependency priority

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -175,22 +175,21 @@ export function prodSharedPlugin(
         orderByDepCount[value.size].set(key, value)
       })
 
-      // dependency nothing is first
-      for (let i = 0; i < orderByDepCount.length; i++) {
-        if (i === 0) {
-          for (const key of orderByDepCount[i].keys()) {
-            priority.push(key)
-          }
-        } else {
-          if (!orderByDepCount[i]) {
-            continue;
-          }
-
-          for (const entries of orderByDepCount[i].entries()) {
-            addDep(entries, priority, depInShared)
-          }
+      // dependency nothing is first,handle index = 0
+      if (orderByDepCount[0]) {
+        for (const key of orderByDepCount[0].keys()) {
+          priority.push(key)
         }
       }
+
+      // handle index >= 1
+      orderByDepCount
+        .filter((item, index) => item && index >= 1)
+        .forEach((item) => {
+          for (const entry of item.entries()) {
+            addDep(entry, priority, depInShared)
+          }
+        })
 
       function addDep([key, value], priority, depInShared) {
         for (const dep of value) {

--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -68,7 +68,7 @@ export function prodSharedPlugin(
               console.log(\`provider support \${name}(\${dep.version}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})\`)
             }
           } else {
-            module = await dep.get(); 
+            module = await dep.get();
           }
         }
         if(module){
@@ -182,6 +182,10 @@ export function prodSharedPlugin(
             priority.push(key)
           }
         } else {
+          if (!orderByDepCount[i]) {
+            continue;
+          }
+
           for (const entries of orderByDepCount[i].entries()) {
             addDep(entries, priority, depInShared)
           }


### PR DESCRIPTION
This PR is about skip the non existing dependency priority.

For example, we have those packages' dependencies like this

```
axios: {},
react: {},
lodash: {},
my-package: { react: {}, lodash: {} },
```

Our `orderByDepCount` will be like this

```
orderByDepCount: [
  Map(3): { axios, react, lodash }, // those packages do not depend on any package
  undefined, // this is empty item because no package has `value.size` is 1
  Map(1): { my-package }, // package my-package depend on react and lodash, the value.size will be 2
]
```

Because there is no package's dependencies with size 1.

So we can filter the `orderByDepCount` element to remove undefined/empty item, or skip the empty item like this one