### PR TITLE
feat: remove rollup generated empty import(import 'filename.js')

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -146,6 +146,10 @@ export function prodSharedPlugin(
     },
 
     outputOptions: function (outputOption) {
+      // remove rollup generated empty imports,like import './filename.js'
+      outputOption.hoistTransitiveImports = false
+
+      // sort shared dep
       const that = this
       const priority: string[] = []
       const depInShared = new Map()


### PR DESCRIPTION
this pr will remove some rollup generated empty import,Just like the following

![image](https://user-images.githubusercontent.com/70385062/142983724-9a4df11a-cb64-4518-ba94-3b3a7258c7be.png)

These parts cause shared to fail because both shared and local dependencies are loaded and can be removed by tweaking the rollup configuration [output.hoistTransitiveImports](https://rollupjs.org/guide/en/#outputhoisttransitiveimports)

more information about those import: [Why do additional imports turn up in my entry chunks when code-splitting](https://rollupjs.org/guide/en/#why-do-additional-imports-turn-up-in-my-entry-chunks-when-code-splitting)