### PR TITLE
fix semver and add pre-release checker

### DIFF
--- a/packages/lib/__tests__/semver.spec.ts
+++ b/packages/lib/__tests__/semver.spec.ts
@@ -2,7 +2,7 @@
 // test cases from https://devhints.io/semver
 
 
-import {satisfy} from "../src/utils/semver";
+import { satisfy } from '../src/utils/semver'
 
 const version = '1.2.3'
 const belowVersion = '1.2.2'
@@ -28,171 +28,190 @@ const specialXRange2 = '1.*'
 
 describe('satisfy ranges', () => {
   test('tilde', () => {
-    expect(satisfy(version, tilde)).toBe(true);
-    expect(satisfy(belowVersion, tilde)).toBe(false);
-    expect(satisfy(aboveVersion, tilde)).toBe(true);
-    expect(satisfy(tildeMaxVersion, tilde)).toBe(false);
-  });
+    expect(satisfy(version, tilde)).toBe(true)
+    expect(satisfy(belowVersion, tilde)).toBe(false)
+    expect(satisfy(aboveVersion, tilde)).toBe(true)
+    expect(satisfy(tildeMaxVersion, tilde)).toBe(false)
+  })
 
   describe('special tilde', () => {
     test('special tilde 1', () => {
-      expect(satisfy('1.2.0', specialTilde1)).toBe(true);
-      expect(satisfy('1.2.4', specialTilde1)).toBe(true);
-      expect(satisfy('1.1.9', specialTilde1)).toBe(false);
-      expect(satisfy('1.3.0', specialTilde1)).toBe(false);
-    });
+      expect(satisfy('1.2.0', specialTilde1)).toBe(true)
+      expect(satisfy('1.2.4', specialTilde1)).toBe(true)
+      expect(satisfy('1.1.9', specialTilde1)).toBe(false)
+      expect(satisfy('1.3.0', specialTilde1)).toBe(false)
+    })
 
     test('special tilde 2', () => {
-      expect(satisfy('1.0.0', specialTilde2)).toBe(true);
-      expect(satisfy('0.0.9', specialTilde2)).toBe(false);
-      expect(satisfy('1.3.0', specialTilde2)).toBe(true);
-      expect(satisfy('2.0.0', specialTilde2)).toBe(false);
-    });
-  });
+      expect(satisfy('1.0.0', specialTilde2)).toBe(true)
+      expect(satisfy('0.0.9', specialTilde2)).toBe(false)
+      expect(satisfy('1.3.0', specialTilde2)).toBe(true)
+      expect(satisfy('2.0.0', specialTilde2)).toBe(false)
+    })
+  })
 
   test('caret', () => {
-    expect(satisfy(version, caret)).toBe(true);
-    expect(satisfy(belowVersion, caret)).toBe(false);
-    expect(satisfy(aboveVersion, caret)).toBe(true);
-    expect(satisfy(caretMaxVersion, caret)).toBe(false);
-  });
+    expect(satisfy(version, caret)).toBe(true)
+    expect(satisfy(belowVersion, caret)).toBe(false)
+    expect(satisfy(aboveVersion, caret)).toBe(true)
+    expect(satisfy(caretMaxVersion, caret)).toBe(false)
+  })
 
   describe('special caret', () => {
     test('special caret 1', () => {
-      expect(satisfy('0.2.3', specialCaret1)).toBe(true);
-      expect(satisfy('0.2.2', specialCaret1)).toBe(false);
-      expect(satisfy('0.2.5', specialCaret1)).toBe(true);
-      expect(satisfy('0.3.0', specialCaret1)).toBe(false);
-    });
+      expect(satisfy('0.2.3', specialCaret1)).toBe(true)
+      expect(satisfy('0.2.2', specialCaret1)).toBe(false)
+      expect(satisfy('0.2.5', specialCaret1)).toBe(true)
+      expect(satisfy('0.3.0', specialCaret1)).toBe(false)
+    })
 
     test('special caret 2', () => {
-      expect(satisfy('0.0.1', specialCaret2)).toBe(true);
-      expect(satisfy('0.0.0', specialCaret2)).toBe(false);
-      expect(satisfy('0.0.2', specialCaret2)).toBe(false);
-    });
+      expect(satisfy('0.0.1', specialCaret2)).toBe(true)
+      expect(satisfy('0.0.0', specialCaret2)).toBe(false)
+      expect(satisfy('0.0.2', specialCaret2)).toBe(false)
+    })
 
     test('special caret 3', () => {
-      expect(satisfy('1.2.0', specialCaret3)).toBe(true);
-      expect(satisfy('1.3.3', specialCaret3)).toBe(true);
-      expect(satisfy('1.1.9', specialCaret3)).toBe(false);
-      expect(satisfy('2.0.0', specialCaret3)).toBe(false);
-    });
+      expect(satisfy('1.2.0', specialCaret3)).toBe(true)
+      expect(satisfy('1.3.3', specialCaret3)).toBe(true)
+      expect(satisfy('1.1.9', specialCaret3)).toBe(false)
+      expect(satisfy('2.0.0', specialCaret3)).toBe(false)
+    })
 
     test('special caret 4', () => {
-      expect(satisfy('1.0.0', specialCaret4)).toBe(true);
-      expect(satisfy('0.0.9', specialCaret4)).toBe(false);
-      expect(satisfy('1.3.0', specialCaret4)).toBe(true);
-      expect(satisfy('2.0.0', specialCaret4)).toBe(false);
-    });
-  });
+      expect(satisfy('1.0.0', specialCaret4)).toBe(true)
+      expect(satisfy('0.0.9', specialCaret4)).toBe(false)
+      expect(satisfy('1.3.0', specialCaret4)).toBe(true)
+      expect(satisfy('2.0.0', specialCaret4)).toBe(false)
+    })
+  })
 
   describe('x ranges', () => {
     test('x range', () => {
-      expect(satisfy('1.0.0', xRange)).toBe(true);
-      expect(satisfy('0.0.9', xRange)).toBe(false);
-      expect(satisfy('1.3.0', xRange)).toBe(true);
-      expect(satisfy('2.0.0', xRange)).toBe(false);
-    });
+      expect(satisfy('1.0.0', xRange)).toBe(true)
+      expect(satisfy('0.0.9', xRange)).toBe(false)
+      expect(satisfy('1.3.0', xRange)).toBe(true)
+      expect(satisfy('2.0.0', xRange)).toBe(false)
+    })
 
-    test.skip('x range 1', () => {
-      expect(satisfy('1.0.0', xRange1)).toBe(true);
-      expect(satisfy('0.0.9', xRange1)).toBe(false);
-      expect(satisfy('1.3.0', xRange1)).toBe(true);
-      expect(satisfy('2.0.0', xRange1)).toBe(false);
-    });
+    test('x range 1', () => {
+      expect(satisfy('1.0.0', xRange1)).toBe(true)
+      expect(satisfy('0.0.9', xRange1)).toBe(true)
+      expect(satisfy('1.3.0', xRange1)).toBe(true)
+      expect(satisfy('2.0.0', xRange1)).toBe(true)
+    })
 
-    test.skip('x range 2', () => {
-      expect(satisfy('1.0.0', xRange2)).toBe(true);
-      expect(satisfy('0.0.9', xRange2)).toBe(false);
-      expect(satisfy('1.3.0', xRange2)).toBe(true);
-      expect(satisfy('2.0.0', xRange2)).toBe(false);
-    });
-  });
+    test('x range 2', () => {
+      expect(satisfy('1.0.0', xRange2)).toBe(true)
+      expect(satisfy('0.0.9', xRange2)).toBe(true)
+      expect(satisfy('1.3.0', xRange2)).toBe(true)
+      expect(satisfy('2.0.0', xRange2)).toBe(true)
+    })
+  })
 
   describe('special x range', () => {
     test('special x range 1', () => {
-      expect(satisfy('1.0.0', specialXRange1)).toBe(true);
-      expect(satisfy('0.0.9', specialXRange1)).toBe(false);
-      expect(satisfy('1.3.0', specialXRange1)).toBe(true);
-      expect(satisfy('2.0.0', specialXRange1)).toBe(false);
-    });
+      expect(satisfy('1.0.0', specialXRange1)).toBe(true)
+      expect(satisfy('0.0.9', specialXRange1)).toBe(false)
+      expect(satisfy('1.3.0', specialXRange1)).toBe(true)
+      expect(satisfy('2.0.0', specialXRange1)).toBe(false)
+    })
 
     test('special x range 2', () => {
-      expect(satisfy('1.0.0', specialXRange2)).toBe(true);
-      expect(satisfy('0.0.9', specialXRange2)).toBe(false);
-      expect(satisfy('1.3.0', specialXRange2)).toBe(true);
-      expect(satisfy('2.0.0', specialXRange2)).toBe(false);
-    });
-  });
-});
+      expect(satisfy('1.0.0', specialXRange2)).toBe(true)
+      expect(satisfy('0.0.9', specialXRange2)).toBe(false)
+      expect(satisfy('1.3.0', specialXRange2)).toBe(true)
+      expect(satisfy('2.0.0', specialXRange2)).toBe(false)
+    })
+  })
+})
 
 describe('simple ranges', () => {
   test('empty operator', () => {
-    expect(satisfy('1.2.3', '1.2.3')).toBe(true);
-    expect(satisfy('1.2.2', '1.2.3')).toBe(false);
-    expect(satisfy('1.2.4', '1.2.3')).toBe(false);
-  });
+    expect(satisfy('1.2.3', '1.2.3')).toBe(true)
+    expect(satisfy('1.2.2', '1.2.3')).toBe(false)
+    expect(satisfy('1.2.4', '1.2.3')).toBe(false)
+  })
 
   test('= operator', () => {
-    expect(satisfy('1.2.3', '=1.2.3')).toBe(true);
-    expect(satisfy('1.2.2', '=1.2.3')).toBe(false);
-    expect(satisfy('1.2.4', '=1.2.3')).toBe(false);
-  });
+    expect(satisfy('1.2.3', '=1.2.3')).toBe(true)
+    expect(satisfy('1.2.2', '=1.2.3')).toBe(false)
+    expect(satisfy('1.2.4', '=1.2.3')).toBe(false)
+  })
 
   test('> operator', () => {
-    expect(satisfy('1.2.3', '>1.2.3')).toBe(false);
-    expect(satisfy('1.2.2', '>1.2.3')).toBe(false);
-    expect(satisfy('1.2.4', '>1.2.3')).toBe(true);
-  });
+    expect(satisfy('1.2.3', '>1.2.3')).toBe(false)
+    expect(satisfy('1.2.2', '>1.2.3')).toBe(false)
+    expect(satisfy('1.2.4', '>1.2.3')).toBe(true)
+  })
 
   test('< operator', () => {
-    expect(satisfy('1.2.3', '<1.2.3')).toBe(false);
-    expect(satisfy('1.2.2', '<1.2.3')).toBe(true);
-    expect(satisfy('1.2.4', '<1.2.3')).toBe(false);
-  });
+    expect(satisfy('1.2.3', '<1.2.3')).toBe(false)
+    expect(satisfy('1.2.2', '<1.2.3')).toBe(true)
+    expect(satisfy('1.2.4', '<1.2.3')).toBe(false)
+  })
 
   test('>= operator', () => {
-    expect(satisfy('1.2.3', '>=1.2.3')).toBe(true);
-    expect(satisfy('1.2.2', '>=1.2.3')).toBe(false);
-    expect(satisfy('1.2.4', '>=1.2.3')).toBe(true);
-  });
+    expect(satisfy('1.2.3', '>=1.2.3')).toBe(true)
+    expect(satisfy('1.2.2', '>=1.2.3')).toBe(false)
+    expect(satisfy('1.2.4', '>=1.2.3')).toBe(true)
+  })
 
   test('<= operator', () => {
-    expect(satisfy('1.2.3', '<=1.2.3')).toBe(true);
-    expect(satisfy('1.2.2', '<=1.2.3')).toBe(true);
-    expect(satisfy('1.2.4', '<=1.2.3')).toBe(false);
-  });
-});
+    expect(satisfy('1.2.3', '<=1.2.3')).toBe(true)
+    expect(satisfy('1.2.2', '<=1.2.3')).toBe(true)
+    expect(satisfy('1.2.4', '<=1.2.3')).toBe(false)
+  })
+})
 
 describe('hyphenated ranges', () => {
   test('normal hyphen', () => {
-    expect(satisfy('1.2.3', '1.2.3 - 2.3.4')).toBe(true);
-    expect(satisfy('1.2.2', '1.2.3 - 2.3.4')).toBe(false);
-    expect(satisfy('1.3.3', '1.2.3 - 2.3.4')).toBe(true);
-    expect(satisfy('2.3.4', '1.2.3 - 2.3.4')).toBe(true);
-    expect(satisfy('2.3.5', '1.2.3 - 2.3.4')).toBe(false);
-  });
+    expect(satisfy('1.2.3', '1.2.3 - 2.3.4')).toBe(true)
+    expect(satisfy('1.2.2', '1.2.3 - 2.3.4')).toBe(false)
+    expect(satisfy('1.3.3', '1.2.3 - 2.3.4')).toBe(true)
+    expect(satisfy('2.3.4', '1.2.3 - 2.3.4')).toBe(true)
+    expect(satisfy('2.3.5', '1.2.3 - 2.3.4')).toBe(false)
+  })
 
   test('partial right hyphen', () => {
-    expect(satisfy('1.2.3', '1.2.3 - 2.3')).toBe(true);
-    expect(satisfy('1.2.2', '1.2.3 - 2.3')).toBe(false);
-    expect(satisfy('1.3.3', '1.2.3 - 2.3')).toBe(true);
-    expect(satisfy('2.3.9', '1.2.3 - 2.3')).toBe(true);
-    expect(satisfy('2.4.0', '1.2.3 - 2.3')).toBe(false);
+    expect(satisfy('1.2.3', '1.2.3 - 2.3')).toBe(true)
+    expect(satisfy('1.2.2', '1.2.3 - 2.3')).toBe(false)
+    expect(satisfy('1.3.3', '1.2.3 - 2.3')).toBe(true)
+    expect(satisfy('2.3.9', '1.2.3 - 2.3')).toBe(true)
+    expect(satisfy('2.4.0', '1.2.3 - 2.3')).toBe(false)
 
-    expect(satisfy('1.2.3', '1.2.3 - 2')).toBe(true);
-    expect(satisfy('1.2.2', '1.2.3 - 2')).toBe(false);
-    expect(satisfy('1.3.3', '1.2.3 - 2')).toBe(true);
-    expect(satisfy('2.9.9', '1.2.3 - 2')).toBe(true);
-    expect(satisfy('3.0.0', '1.2.3 - 2')).toBe(false);
-  });
+    expect(satisfy('1.2.3', '1.2.3 - 2')).toBe(true)
+    expect(satisfy('1.2.2', '1.2.3 - 2')).toBe(false)
+    expect(satisfy('1.3.3', '1.2.3 - 2')).toBe(true)
+    expect(satisfy('2.9.9', '1.2.3 - 2')).toBe(true)
+    expect(satisfy('3.0.0', '1.2.3 - 2')).toBe(false)
+  })
 
   test('partial left hyphen', () => {
-    expect(satisfy('1.2.0', '1.2 - 2.3.0')).toBe(true);
-    expect(satisfy('1.1.0', '1.2 - 2.3.0')).toBe(false);
-    expect(satisfy('1.2.2', '1.2 - 2.3.0')).toBe(true);
-    expect(satisfy('1.3.3', '1.2 - 2.3.0')).toBe(true);
-    expect(satisfy('2.3.0', '1.2 - 2.3.0')).toBe(true);
-    expect(satisfy('2.4.0', '1.2 - 2.3.0')).toBe(false);
-  });
-});
+    expect(satisfy('1.2.0', '1.2 - 2.3.0')).toBe(true)
+    expect(satisfy('1.1.0', '1.2 - 2.3.0')).toBe(false)
+    expect(satisfy('1.2.2', '1.2 - 2.3.0')).toBe(true)
+    expect(satisfy('1.3.3', '1.2 - 2.3.0')).toBe(true)
+    expect(satisfy('2.3.0', '1.2 - 2.3.0')).toBe(true)
+    expect(satisfy('2.4.0', '1.2 - 2.3.0')).toBe(false)
+  })
+})
+
+describe('pre-release', () => {
+  test('fixed version', () => {
+    expect(satisfy('1.2.3-prerelease+build', '1.2.3-prerelease+build')).toBe(true)
+    expect(satisfy('1.2.3-prerelease', '1.2.3-prerelease+build')).toBe(true)
+    expect(satisfy('4.0.0', '4.0.0-alpha.57')).toBe(false)
+    expect(satisfy('4.0.0-alpha.57', '4.0.0-alpha.57')).toBe(true)
+    expect(satisfy('4.0.0-alpha.58', '4.0.0-alpha.57')).toBe(false)
+    expect(satisfy('4.0.0-alpha.56', '4.0.0-alpha.57')).toBe(false)
+  })
+
+  test('caret version', () => {
+    expect(satisfy('4.0.0', '^4.0.0-alpha.57')).toBe(true)
+    expect(satisfy('4.0.0-alpha.58', '^4.0.0-alpha.57')).toBe(true)
+    expect(satisfy('4.0.0-alpha.56', '^4.0.0-alpha.57')).toBe(false)
+    expect(satisfy('4.0.0-beta.56', '^4.0.0-alpha.57')).toBe(true)
+    expect(satisfy('4.0.0-alpha.58', '^4.0.0-beta.57')).toBe(false)
+  })
+})

--- a/packages/lib/src/utils/semver/compare.ts
+++ b/packages/lib/src/utils/semver/compare.ts
@@ -4,12 +4,12 @@ export interface CompareAtom {
   major: string
   minor: string
   patch: string
-  preRelease?: string
+  preRelease?: string[]
 }
 
 function compareAtom(rangeAtom: string | number, versionAtom: string | number): number {
-  rangeAtom = +rangeAtom
-  versionAtom = +versionAtom
+  rangeAtom = +rangeAtom || rangeAtom
+  versionAtom = +versionAtom || versionAtom
 
   if (rangeAtom > versionAtom) {
     return 1
@@ -22,10 +22,53 @@ function compareAtom(rangeAtom: string | number, versionAtom: string | number): 
   return -1
 }
 
+function comparePreRelease(rangeAtom: CompareAtom, versionAtom: CompareAtom): number {
+  const { preRelease: rangePreRelease } = rangeAtom
+  const { preRelease: versionPreRelease } = versionAtom
+
+  if (rangePreRelease === undefined && !!versionPreRelease) {
+    return 1
+  }
+
+  if (!!rangePreRelease && versionPreRelease === undefined) {
+    return -1
+  }
+
+  if (rangePreRelease === undefined && versionPreRelease === undefined) {
+    return 0
+  }
+
+  for (let i = 0, n = rangePreRelease!.length; i <= n; i++) {
+    const rangeElement = rangePreRelease![i]
+    const versionElement = versionPreRelease![i]
+
+    if (rangeElement === versionElement) {
+      continue;
+    }
+
+    if (rangeElement === undefined && versionElement === undefined) {
+      return 0
+    }
+
+    if (!rangeElement) {
+      return 1
+    }
+
+    if (!versionElement) {
+      return -1
+    }
+
+    return compareAtom(rangeElement, versionElement)
+  }
+
+  return 0
+}
+
 function compareVersion(rangeAtom: CompareAtom, versionAtom: CompareAtom): number {
   return compareAtom(rangeAtom.major, versionAtom.major)
     || compareAtom(rangeAtom.minor, versionAtom.minor)
     || compareAtom(rangeAtom.patch, versionAtom.patch)
+    || comparePreRelease(rangeAtom, versionAtom)
 }
 
 function eq(rangeAtom: CompareAtom, versionAtom: CompareAtom): boolean {
@@ -45,6 +88,9 @@ export function compare(rangeAtom: CompareAtom, versionAtom: CompareAtom): boole
       return compareVersion(rangeAtom, versionAtom) > 0
     case '<=':
       return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0
+    case undefined: { // mean * or x -> all versions
+      return true
+    }
     default:
       return false
   }

--- a/packages/lib/src/utils/semver/index.ts
+++ b/packages/lib/src/utils/semver/index.ts
@@ -1,4 +1,4 @@
-import { extractComparator, pipe } from './utils'
+import { combineVersion, extractComparator, pipe } from './utils'
 import {
   parseHyphen,
   parseComparatorTrim,
@@ -52,7 +52,7 @@ function parseRange(range: string) {
   )(range.trim()).split(/\s+/).join(' ')
 }
 
-function satisfy(version: string, range: string): boolean {
+export function satisfy(version: string, range: string): boolean {
   if (!version) {
     return false
   }
@@ -66,14 +66,14 @@ function satisfy(version: string, range: string): boolean {
     return false
   }
 
-  const [, versionOperator, versionRaw, versionMajor, versionMinor, versionPatch, versionPreRelease] = extractedVersion
+  const [, versionOperator, , versionMajor, versionMinor, versionPatch, versionPreRelease] = extractedVersion
   const versionAtom: CompareAtom = {
     operator: versionOperator,
-    version: versionRaw,
+    version: combineVersion(versionMajor, versionMinor, versionPatch, versionPreRelease), // exclude build atom
     major: versionMajor,
     minor: versionMinor,
     patch: versionPatch,
-    preRelease: versionPreRelease,
+    preRelease: versionPreRelease?.split('.'),
   }
 
   for (const comparator of comparators) {
@@ -83,25 +83,20 @@ function satisfy(version: string, range: string): boolean {
       return false
     }
 
-    const [, rangeOperator, rangeRaw, rangeMajor, rangeMinor, rangePatch, rangePreRelease] = extractedComparator
+    const [, rangeOperator, , rangeMajor, rangeMinor, rangePatch, rangePreRelease] = extractedComparator
     const rangeAtom: CompareAtom = {
       operator: rangeOperator,
-      version: rangeRaw,
+      version: combineVersion(rangeMajor, rangeMinor, rangePatch, rangePreRelease), // exclude build atom
       major: rangeMajor,
       minor: rangeMinor,
       patch: rangePatch,
-      preRelease: rangePreRelease,
+      preRelease: rangePreRelease?.split('.'),
     }
 
-    const a = compare(rangeAtom, versionAtom)
-    if (!a) {
+    if (!compare(rangeAtom, versionAtom)) {
       return false // early return
     }
   }
 
   return true
-}
-
-export {
-  satisfy
 }

--- a/packages/lib/src/utils/semver/utils.ts
+++ b/packages/lib/src/utils/semver/utils.ts
@@ -59,3 +59,13 @@ export function pipe(...fns: ((params: any) => any)[]) {
 export function extractComparator(comparatorString: string): RegExpMatchArray | null {
   return comparatorString.match(parseRegex(comparator))
 }
+
+export function combineVersion(major: string, minor: string, patch: string, preRelease: string): string {
+  const mainVersion = `${major}.${minor}.${patch}`
+
+  if (preRelease) {
+    return `${mainVersion}-${preRelease}`
+  }
+
+  return mainVersion
+}


### PR DESCRIPTION
fix semver logic when checking `x range` (`*` and `x`) and add pre-release logic checker