### PR TITLE
shared support monoRepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             node_version: 16
       fail-fast: false
 
-    name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
+    name: 'Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 6
-      
+
       - name: Cache pnpm modules
         uses: actions/cache@v2
         with:
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install deps
         run: pnpm install
@@ -57,7 +57,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: "Lint: node-16, ubuntu-latest"
+    name: 'Lint: node-16, ubuntu-latest'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install deps
         run: pnpm install

--- a/packages/lib/__tests__/semver.spec.ts
+++ b/packages/lib/__tests__/semver.spec.ts
@@ -1,6 +1,4 @@
-
 // test cases from https://devhints.io/semver
-
 
 import { satisfy } from '../src/utils/semver'
 
@@ -199,7 +197,9 @@ describe('hyphenated ranges', () => {
 
 describe('pre-release', () => {
   test('fixed version', () => {
-    expect(satisfy('1.2.3-prerelease+build', '1.2.3-prerelease+build')).toBe(true)
+    expect(satisfy('1.2.3-prerelease+build', '1.2.3-prerelease+build')).toBe(
+      true
+    )
     expect(satisfy('1.2.3-prerelease', '1.2.3-prerelease+build')).toBe(true)
     expect(satisfy('4.0.0', '4.0.0-alpha.57')).toBe(false)
     expect(satisfy('4.0.0-alpha.57', '4.0.0-alpha.57')).toBe(true)

--- a/packages/lib/__tests__/utils.spec.ts
+++ b/packages/lib/__tests__/utils.spec.ts
@@ -1,8 +1,8 @@
 import {
-  parseOptions,
+  getModuleMarker,
   isSameFilepath,
-  removeNonLetter,
-  getModuleMarker
+  parseOptions,
+  removeNonLetter
 } from '../src/utils'
 import { ExposesObject } from '../types'
 

--- a/packages/lib/rollup.config.js
+++ b/packages/lib/rollup.config.js
@@ -6,24 +6,20 @@ import pkg from './package.json'
 export default [
   {
     input: 'src/utils/semver/index.ts',
-    plugins: [
-      typescript({include: './src/**/*.ts', module: 'esnext'})
-    ],
+    plugins: [typescript({ include: './src/**/*.ts', module: 'esnext' })],
     external: ['path'],
-    output: [
-      {format: 'esm', file: 'dist/satisfy.js'}
-    ]
+    output: [{ format: 'esm', file: 'dist/satisfy.js' }]
   },
   {
     input: 'src/index.ts',
     plugins: [
       resolve(),
-      typescript({include: './src/**/*.ts', module: 'esnext'})
+      typescript({ include: './src/**/*.ts', module: 'esnext' })
     ],
     external: ['path'],
     output: [
-      {format: 'cjs', file: pkg.main, exports: 'auto'},
-      {format: 'esm', file: pkg.module}
+      { format: 'cjs', file: pkg.main, exports: 'auto' },
+      { format: 'esm', file: pkg.module }
     ]
   }
 ]

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -1,5 +1,9 @@
 import { UserConfig } from 'vite'
-import { ConfigTypeSet, RemotesConfig, VitePluginFederationOptions } from 'types'
+import {
+  ConfigTypeSet,
+  RemotesConfig,
+  VitePluginFederationOptions
+} from 'types'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { AcornNode, TransformPluginContext } from 'rollup'
@@ -29,11 +33,11 @@ export function devRemotePlugin(
       __federation__: `
 const remotesMap = {
   ${remotes
-          .map(
-              (remote) =>
-                  `'${remote.id}':{url:'${remote.config.external[0]}',format:'${remote.config.format}'}`
-          )
-          .join(',\n  ')}
+    .map(
+      (remote) =>
+        `'${remote.id}':{url:'${remote.config.external[0]}',format:'${remote.config.format}'}`
+    )
+    .join(',\n  ')}
 };
 const loadJS = (url, fn) => {
   const script = document.createElement('script')
@@ -88,18 +92,18 @@ export default {
     },
     config(config: UserConfig) {
       // need to include remotes in the optimizeDeps.exclude
-        if (parsedOptions.devRemote.length) {
-            const excludeRemotes: string[] = []
-            parsedOptions.devRemote.forEach(item => excludeRemotes.push(item[0]));
-            let optimizeDeps = config.optimizeDeps;
-            if (!optimizeDeps) {
-                optimizeDeps = config.optimizeDeps = {};
-            }
-            if (!optimizeDeps.exclude) {
-                optimizeDeps.exclude = [];
-            }
-            optimizeDeps.exclude = optimizeDeps.exclude.concat(excludeRemotes);
+      if (parsedOptions.devRemote.length) {
+        const excludeRemotes: string[] = []
+        parsedOptions.devRemote.forEach((item) => excludeRemotes.push(item[0]))
+        let optimizeDeps = config.optimizeDeps
+        if (!optimizeDeps) {
+          optimizeDeps = config.optimizeDeps = {}
         }
+        if (!optimizeDeps.exclude) {
+          optimizeDeps.exclude = []
+        }
+        optimizeDeps.exclude = optimizeDeps.exclude.concat(excludeRemotes)
+      }
     },
 
     configureServer(server: ViteDevServer) {

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -46,9 +46,7 @@ export function prodExposePlugin(
         console.warn('The remote style takes effect only when the build.target option in the vite.config.ts file is higher than that of "es2020".')
         return
       }
-      const curUrl = metaUrl.substring(0, metaUrl.lastIndexOf('${
-        options.filename
-      }'))
+      const curUrl = metaUrl.substring(0, metaUrl.lastIndexOf('${options.filename}'))
       const element = document.head.appendChild(document.createElement('link'))
       element.href = curUrl + cssFilePath
       element.rel = 'stylesheet'
@@ -189,7 +187,7 @@ export function prodExposePlugin(
     // when build.cssCodeSplit: false, all files are aggregated into style.xxxxxxxx.css
     if (moduleCssFileMap.size === 0) {
       for (const file in bundle) {
-        cssFileMap.forEach(function(css) {
+        cssFileMap.forEach(function (css) {
           moduleCssFileMap.set(bundle[file].facadeModuleId, css)
         })
       }

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -1,11 +1,11 @@
-import {RemotesConfig, VitePluginFederationOptions} from 'types'
-import {walk} from 'estree-walker'
+import { RemotesConfig, VitePluginFederationOptions } from 'types'
+import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
-import {AcornNode, TransformPluginContext} from 'rollup'
-import {getModuleMarker, parseRemoteOptions, removeNonLetter} from '../utils'
-import {builderInfo, parsedOptions} from '../public'
+import { AcornNode, TransformPluginContext } from 'rollup'
+import { getModuleMarker, parseRemoteOptions, removeNonLetter } from '../utils'
+import { builderInfo, parsedOptions } from '../public'
 import * as path from 'path'
-import {PluginHooks} from '../../types/pluginHooks'
+import { PluginHooks } from '../../types/pluginHooks'
 import * as fs from 'fs'
 
 export function prodRemotePlugin(
@@ -95,11 +95,12 @@ export default {
           if (!sharedInfo[1].emitFile) {
             sharedInfo[1].emitFile = this.emitFile({
               type: 'chunk',
-              id: sharedInfo[0],
+              id: sharedInfo[1].id ?? sharedInfo[0],
               fileName: `${
                 builderInfo.assetsDir ? builderInfo.assetsDir + '/' : ''
+              }${
+                sharedInfo[1].root ? sharedInfo[1].root[0] + '/' : ''
               }__federation_shared_${removeNonLetter(sharedInfo[0])}.js`,
-              name: sharedInfo[0],
               preserveSignature: 'allow-extension'
             })
           }
@@ -111,7 +112,9 @@ export default {
               (sharedInfo) =>
                 `'${removeNonLetter(
                   sharedInfo[0]
-                )}':{get:()=>__federation_import('./${path.basename(
+                )}':{get:()=>__federation_import('./${
+                  sharedInfo[1].root ? `${sharedInfo[1].root[0]}/` : ''
+                }${path.basename(
                   this.getFileName(sharedInfo[1].emitFile)
                 )}'),import:${sharedInfo[1].import}${
                   sharedInfo[1].requiredVersion
@@ -126,10 +129,12 @@ export default {
           )
         }
 
-        if(id === '\0virtual:__federation_lib_semver'){
-          const federationId = (await this.resolve('@originjs/vite-plugin-federation'))?.id;
-          const satisfyId = `${path.dirname(federationId!)}/satisfy.js`;
-          return fs.readFileSync(satisfyId, {encoding: 'utf-8'});
+        if (id === '\0virtual:__federation_lib_semver') {
+          const federationId = (
+            await this.resolve('@originjs/vite-plugin-federation')
+          )?.id
+          const satisfyId = `${path.dirname(federationId!)}/satisfy.js`
+          return fs.readFileSync(satisfyId, { encoding: 'utf-8' })
         }
       }
 

--- a/packages/lib/src/utils/semver/compare.ts
+++ b/packages/lib/src/utils/semver/compare.ts
@@ -7,7 +7,10 @@ export interface CompareAtom {
   preRelease?: string[]
 }
 
-function compareAtom(rangeAtom: string | number, versionAtom: string | number): number {
+function compareAtom(
+  rangeAtom: string | number,
+  versionAtom: string | number
+): number {
   rangeAtom = +rangeAtom || rangeAtom
   versionAtom = +versionAtom || versionAtom
 
@@ -22,7 +25,10 @@ function compareAtom(rangeAtom: string | number, versionAtom: string | number): 
   return -1
 }
 
-function comparePreRelease(rangeAtom: CompareAtom, versionAtom: CompareAtom): number {
+function comparePreRelease(
+  rangeAtom: CompareAtom,
+  versionAtom: CompareAtom
+): number {
   const { preRelease: rangePreRelease } = rangeAtom
   const { preRelease: versionPreRelease } = versionAtom
 
@@ -43,7 +49,7 @@ function comparePreRelease(rangeAtom: CompareAtom, versionAtom: CompareAtom): nu
     const versionElement = versionPreRelease![i]
 
     if (rangeElement === versionElement) {
-      continue;
+      continue
     }
 
     if (rangeElement === undefined && versionElement === undefined) {
@@ -64,18 +70,26 @@ function comparePreRelease(rangeAtom: CompareAtom, versionAtom: CompareAtom): nu
   return 0
 }
 
-function compareVersion(rangeAtom: CompareAtom, versionAtom: CompareAtom): number {
-  return compareAtom(rangeAtom.major, versionAtom.major)
-    || compareAtom(rangeAtom.minor, versionAtom.minor)
-    || compareAtom(rangeAtom.patch, versionAtom.patch)
-    || comparePreRelease(rangeAtom, versionAtom)
+function compareVersion(
+  rangeAtom: CompareAtom,
+  versionAtom: CompareAtom
+): number {
+  return (
+    compareAtom(rangeAtom.major, versionAtom.major) ||
+    compareAtom(rangeAtom.minor, versionAtom.minor) ||
+    compareAtom(rangeAtom.patch, versionAtom.patch) ||
+    comparePreRelease(rangeAtom, versionAtom)
+  )
 }
 
 function eq(rangeAtom: CompareAtom, versionAtom: CompareAtom): boolean {
   return rangeAtom.version === versionAtom.version
 }
 
-export function compare(rangeAtom: CompareAtom, versionAtom: CompareAtom): boolean {
+export function compare(
+  rangeAtom: CompareAtom,
+  versionAtom: CompareAtom
+): boolean {
   switch (rangeAtom.operator) {
     case '':
     case '=':
@@ -83,12 +97,17 @@ export function compare(rangeAtom: CompareAtom, versionAtom: CompareAtom): boole
     case '>':
       return compareVersion(rangeAtom, versionAtom) < 0
     case '>=':
-      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0
+      return (
+        eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0
+      )
     case '<':
       return compareVersion(rangeAtom, versionAtom) > 0
     case '<=':
-      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0
-    case undefined: { // mean * or x -> all versions
+      return (
+        eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0
+      )
+    case undefined: {
+      // mean * or x -> all versions
       return true
     }
     default:

--- a/packages/lib/src/utils/semver/constants.ts
+++ b/packages/lib/src/utils/semver/constants.ts
@@ -28,4 +28,4 @@ export const tilde = `^${loneTilde}${xRangePlain}$`
 export const xRange = `^${gtlt}\\s*${xRangePlain}$`
 export const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`
 // copy from semver package
-export const gte0 = '^\\s*>=\\s*0.0.0\\s*$';
+export const gte0 = '^\\s*>=\\s*0.0.0\\s*$'

--- a/packages/lib/src/utils/semver/index.ts
+++ b/packages/lib/src/utils/semver/index.ts
@@ -8,7 +8,7 @@ import {
   parseTildes,
   parseXRanges,
   parseStar,
-  parseGTE0,
+  parseGTE0
 } from './parser'
 import { compare, CompareAtom } from './compare'
 
@@ -31,7 +31,7 @@ function parseComparatorString(range: string): string {
     // ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0-0
     parseTildes,
     parseXRanges,
-    parseStar,
+    parseStar
   )(range)
 }
 
@@ -48,8 +48,10 @@ function parseRange(range: string) {
     parseTildeTrim,
     // handle trim caret
     // `^ 1.2.3` => `^1.2.3`
-    parseCaretTrim,
-  )(range.trim()).split(/\s+/).join(' ')
+    parseCaretTrim
+  )(range.trim())
+    .split(/\s+/)
+    .join(' ')
 }
 
 export function satisfy(version: string, range: string): boolean {
@@ -58,22 +60,40 @@ export function satisfy(version: string, range: string): boolean {
   }
 
   const parsedRange = parseRange(range)
-  const parsedComparator = parsedRange.split(' ').map((rangeVersion) => parseComparatorString(rangeVersion)).join(' ')
-  const comparators = parsedComparator.split(/\s+/).map((comparator) => parseGTE0(comparator))
+  const parsedComparator = parsedRange
+    .split(' ')
+    .map((rangeVersion) => parseComparatorString(rangeVersion))
+    .join(' ')
+  const comparators = parsedComparator
+    .split(/\s+/)
+    .map((comparator) => parseGTE0(comparator))
   const extractedVersion = extractComparator(version)
 
   if (!extractedVersion) {
     return false
   }
 
-  const [, versionOperator, , versionMajor, versionMinor, versionPatch, versionPreRelease] = extractedVersion
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion
   const versionAtom: CompareAtom = {
     operator: versionOperator,
-    version: combineVersion(versionMajor, versionMinor, versionPatch, versionPreRelease), // exclude build atom
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ), // exclude build atom
     major: versionMajor,
     minor: versionMinor,
     patch: versionPatch,
-    preRelease: versionPreRelease?.split('.'),
+    preRelease: versionPreRelease?.split('.')
   }
 
   for (const comparator of comparators) {
@@ -83,14 +103,27 @@ export function satisfy(version: string, range: string): boolean {
       return false
     }
 
-    const [, rangeOperator, , rangeMajor, rangeMinor, rangePatch, rangePreRelease] = extractedComparator
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator
     const rangeAtom: CompareAtom = {
       operator: rangeOperator,
-      version: combineVersion(rangeMajor, rangeMinor, rangePatch, rangePreRelease), // exclude build atom
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ), // exclude build atom
       major: rangeMajor,
       minor: rangeMinor,
       patch: rangePatch,
-      preRelease: rangePreRelease?.split('.'),
+      preRelease: rangePreRelease?.split('.')
     }
 
     if (!compare(rangeAtom, versionAtom)) {

--- a/packages/lib/src/utils/semver/parser.ts
+++ b/packages/lib/src/utils/semver/parser.ts
@@ -8,7 +8,7 @@ import {
   star,
   tilde,
   tildeTrim,
-  xRange,
+  xRange
 } from './constants'
 
 export function parseHyphen(range: string): string {
@@ -26,7 +26,7 @@ export function parseHyphen(range: string): string {
       toMajor,
       toMinor,
       toPatch,
-      toPreRelease,
+      toPreRelease
     ) => {
       if (isXVersion(fromMajor)) {
         from = ''
@@ -50,8 +50,8 @@ export function parseHyphen(range: string): string {
         to = `<=${to}`
       }
 
-      return (`${from} ${to}`).trim()
-    },
+      return `${from} ${to}`.trim()
+    }
   )
 }
 
@@ -68,129 +68,165 @@ export function parseCaretTrim(range: string): string {
 }
 
 export function parseCarets(range: string): string {
-  return range.trim().split(/\s+/).map((rangeVersion) => {
-    return rangeVersion.replace(parseRegex(caret), (_, major, minor, patch, preRelease) => {
-      if (isXVersion(major)) {
-        return ''
-      } else if (isXVersion(minor)) {
-        return `>=${major}.0.0 <${+major + 1}.0.0-0`
-      } else if (isXVersion(patch)) {
-        if (major === '0') {
-          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`
-        } else {
-          return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`
-        }
-      } else if (preRelease) {
-        if (major === '0') {
-          if (minor === '0') {
-            return `>=${major}.${minor}.${patch}-${preRelease} <${major}.${minor}.${+patch + 1}-0`
+  return range
+    .trim()
+    .split(/\s+/)
+    .map((rangeVersion) => {
+      return rangeVersion.replace(
+        parseRegex(caret),
+        (_, major, minor, patch, preRelease) => {
+          if (isXVersion(major)) {
+            return ''
+          } else if (isXVersion(minor)) {
+            return `>=${major}.0.0 <${+major + 1}.0.0-0`
+          } else if (isXVersion(patch)) {
+            if (major === '0') {
+              return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`
+            } else {
+              return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`
+            }
+          } else if (preRelease) {
+            if (major === '0') {
+              if (minor === '0') {
+                return `>=${major}.${minor}.${patch}-${preRelease} <${major}.${minor}.${
+                  +patch + 1
+                }-0`
+              } else {
+                return `>=${major}.${minor}.${patch}-${preRelease} <${major}.${
+                  +minor + 1
+                }.0-0`
+              }
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease} <${
+                +major + 1
+              }.0.0-0`
+            }
           } else {
-            return `>=${major}.${minor}.${patch}-${preRelease} <${major}.${+minor + 1}.0-0`
-          }
-        } else {
-          return `>=${major}.${minor}.${patch}-${preRelease} <${+major + 1}.0.0-0`
-        }
-      } else {
-        if (major === '0') {
-          if (minor === '0') {
-            return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`
-          } else {
-            return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`
-          }
-        }
+            if (major === '0') {
+              if (minor === '0') {
+                return `>=${major}.${minor}.${patch} <${major}.${minor}.${
+                  +patch + 1
+                }-0`
+              } else {
+                return `>=${major}.${minor}.${patch} <${major}.${
+                  +minor + 1
+                }.0-0`
+              }
+            }
 
-        return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`
-      }
+            return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`
+          }
+        }
+      )
     })
-  }).join(' ')
+    .join(' ')
 }
 
 export function parseTildes(range: string): string {
-  return range.trim().split(/\s+/).map((rangeVersion) => {
-    return rangeVersion.replace(parseRegex(tilde), (_, major, minor, patch, preRelease) => {
-      if (isXVersion(major)) {
-        return ''
-      } else if (isXVersion(minor)) {
-        return `>=${major}.0.0 <${+major + 1}.0.0-0`
-      } else if (isXVersion(patch)) {
-        return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`
-      } else if (preRelease) {
-        return `>=${major}.${minor}.${patch}-${preRelease} <${major}.${+minor + 1}.0-0`
-      }
+  return range
+    .trim()
+    .split(/\s+/)
+    .map((rangeVersion) => {
+      return rangeVersion.replace(
+        parseRegex(tilde),
+        (_, major, minor, patch, preRelease) => {
+          if (isXVersion(major)) {
+            return ''
+          } else if (isXVersion(minor)) {
+            return `>=${major}.0.0 <${+major + 1}.0.0-0`
+          } else if (isXVersion(patch)) {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`
+          } else if (preRelease) {
+            return `>=${major}.${minor}.${patch}-${preRelease} <${major}.${
+              +minor + 1
+            }.0-0`
+          }
 
-      return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`
+          return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`
+        }
+      )
     })
-  }).join(' ')
+    .join(' ')
 }
 
 export function parseXRanges(range: string): string {
-  return range.split(/\s+/).map((rangeVersion) => {
-    return rangeVersion.trim().replace(parseRegex(xRange), (ret, gtlt, major, minor, patch, preRelease) => {
-      const isXMajor = isXVersion(major)
-      const isXMinor = isXMajor || isXVersion(minor)
-      const isXPatch = isXMinor || isXVersion(patch)
+  return range
+    .split(/\s+/)
+    .map((rangeVersion) => {
+      return rangeVersion
+        .trim()
+        .replace(
+          parseRegex(xRange),
+          (ret, gtlt, major, minor, patch, preRelease) => {
+            const isXMajor = isXVersion(major)
+            const isXMinor = isXMajor || isXVersion(minor)
+            const isXPatch = isXMinor || isXVersion(patch)
 
-      if (gtlt === '=' && isXPatch) {
-        gtlt = ''
-      }
+            if (gtlt === '=' && isXPatch) {
+              gtlt = ''
+            }
 
-      preRelease = ''
+            preRelease = ''
 
-      if (isXMajor) {
-        if (gtlt === '>' || gtlt === '<') {
-          // nothing is allowed
-          return '<0.0.0-0'
-        } else {
-          // nothing is forbidden
-          return '*'
-        }
-      } else if (gtlt && isXPatch) {
-        // replace X with 0
-        if (isXMinor) {
-          minor = 0
-        }
+            if (isXMajor) {
+              if (gtlt === '>' || gtlt === '<') {
+                // nothing is allowed
+                return '<0.0.0-0'
+              } else {
+                // nothing is forbidden
+                return '*'
+              }
+            } else if (gtlt && isXPatch) {
+              // replace X with 0
+              if (isXMinor) {
+                minor = 0
+              }
 
-        patch = 0
+              patch = 0
 
-        if (gtlt === '>') {
-          // >1 => >=2.0.0
-          // >1.2 => >=1.3.0
-          gtlt = '>='
+              if (gtlt === '>') {
+                // >1 => >=2.0.0
+                // >1.2 => >=1.3.0
+                gtlt = '>='
 
-          if (isXMinor) {
-            major = +major + 1
-            minor = 0
-            patch = 0
-          } else {
-            minor = +minor + 1
-            patch = 0
+                if (isXMinor) {
+                  major = +major + 1
+                  minor = 0
+                  patch = 0
+                } else {
+                  minor = +minor + 1
+                  patch = 0
+                }
+              } else if (gtlt === '<=') {
+                // <=0.7.x is actually <0.8.0, since any 0.7.x should pass
+                // Similarly, <=7.x is actually <8.0.0, etc.
+                gtlt = '<'
+
+                if (isXMinor) {
+                  major = +major + 1
+                } else {
+                  minor = +minor + 1
+                }
+              }
+
+              if (gtlt === '<') {
+                preRelease = '-0'
+              }
+
+              return `${gtlt + major}.${minor}.${patch}${preRelease}`
+            } else if (isXMinor) {
+              return `>=${major}.0.0${preRelease} <${+major + 1}.0.0-0`
+            } else if (isXPatch) {
+              return `>=${major}.${minor}.0${preRelease} <${major}.${
+                +minor + 1
+              }.0-0`
+            }
+
+            return ret
           }
-        } else if (gtlt === '<=') {
-          // <=0.7.x is actually <0.8.0, since any 0.7.x should pass
-          // Similarly, <=7.x is actually <8.0.0, etc.
-          gtlt = '<'
-
-          if (isXMinor) {
-            major = +major + 1
-          } else {
-            minor = +minor + 1
-          }
-        }
-
-        if (gtlt === '<') {
-          preRelease = '-0'
-        }
-
-        return `${gtlt + major}.${minor}.${patch}${preRelease}`
-      } else if (isXMinor) {
-        return `>=${major}.0.0${preRelease} <${+major + 1}.0.0-0`
-      } else if (isXPatch) {
-        return `>=${major}.${minor}.0${preRelease} <${major}.${+minor + 1}.0-0`
-      }
-
-      return ret
+        )
     })
-  }).join(' ')
+    .join(' ')
 }
 
 export function parseStar(range: string): string {

--- a/packages/lib/src/utils/semver/utils.ts
+++ b/packages/lib/src/utils/semver/utils.ts
@@ -56,11 +56,18 @@ export function pipe(...fns: ((params: any) => any)[]) {
   }
 }
 
-export function extractComparator(comparatorString: string): RegExpMatchArray | null {
+export function extractComparator(
+  comparatorString: string
+): RegExpMatchArray | null {
   return comparatorString.match(parseRegex(comparator))
 }
 
-export function combineVersion(major: string, minor: string, patch: string, preRelease: string): string {
+export function combineVersion(
+  major: string,
+  minor: string,
+  patch: string,
+  preRelease: string
+): string {
   const mainVersion = `${major}.${minor}.${patch}`
 
   if (preRelease) {


### PR DESCRIPTION
When `rollup` can't parse some monoRepo in shared, such as `primevue`, the root package.json doesn't specify main and export fields, so it will report an error, like the following configuration 
``` javascript
 shared:['vue','primevue']
```
try to switch to 
``` javascript
 shared:['vue' ,'primevue/button','primevue/dialog'.... ... and so on]
```
 this configuration is working, but it will cause the shared configuration to be too large, so with this PR, this PR will now automatically traverse the folders under primevue for parsing after submission, generating a chunk for each repository under monoRepo, so if you are just using a component, it is recommended to use `shared:['vue','primevue/button']` for manual configuration, and `shared:['vue','primevue']` for extensive use of components