### PR TITLE
feat: add `registerPlugins` support command & chore ts

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "rollup -c",
+    "dev": "rollup -c --watch",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path ."
   },
   "dependencies": {

--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -1,7 +1,7 @@
 import { parseExposeOptions } from '../utils'
 import { parsedOptions } from '../public'
-import { VitePluginFederationOptions } from 'types'
-import { PluginHooks } from '../../types/pluginHooks'
+import type { VitePluginFederationOptions } from 'types'
+import type { PluginHooks } from '../../types/pluginHooks'
 
 export function devExposePlugin(
   options: VitePluginFederationOptions

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -1,16 +1,16 @@
-import { UserConfig } from 'vite'
-import {
+import type { UserConfig } from 'vite'
+import type {
   ConfigTypeSet,
   RemotesConfig,
   VitePluginFederationOptions
 } from 'types'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
-import { AcornNode, TransformPluginContext } from 'rollup'
-import { Hostname, ViteDevServer } from '../../types/viteDevServer'
+import type { AcornNode, TransformPluginContext } from 'rollup'
+import type { Hostname, ViteDevServer } from '../../types/viteDevServer'
 import { getModuleMarker, normalizePath, parseRemoteOptions } from '../utils'
 import { builderInfo, parsedOptions } from '../public'
-import { PluginHooks } from '../../types/pluginHooks'
+import type { PluginHooks } from '../../types/pluginHooks'
 
 export function devRemotePlugin(
   options: VitePluginFederationOptions

--- a/packages/lib/src/dev/shared-development.ts
+++ b/packages/lib/src/dev/shared-development.ts
@@ -1,7 +1,7 @@
-import { PluginHooks } from '../../types/pluginHooks'
+import type { PluginHooks } from '../../types/pluginHooks'
 import { parseSharedOptions } from '../utils'
 import { parsedOptions } from '../public'
-import { VitePluginFederationOptions } from 'types'
+import type { VitePluginFederationOptions } from 'types'
 
 export function devSharedPlugin(
   options: VitePluginFederationOptions

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -1,4 +1,4 @@
-import * as path from 'path'
+import { resolve, parse, basename, extname } from 'path'
 import { getModuleMarker, normalizePath, parseExposeOptions } from '../utils'
 import {
   builderInfo,
@@ -9,9 +9,9 @@ import {
   parsedOptions,
   SHARED
 } from '../public'
-import { AcornNode } from 'rollup'
-import { VitePluginFederationOptions } from 'types'
-import { PluginHooks } from '../../types/pluginHooks'
+import type { AcornNode } from 'rollup'
+import type { VitePluginFederationOptions } from 'types'
+import type { PluginHooks } from '../../types/pluginHooks'
 import MagicString from 'magic-string'
 import { walk } from 'estree-walker'
 
@@ -24,7 +24,7 @@ export function prodExposePlugin(
   for (const item of parsedOptions.prodExpose) {
     const moduleName = getModuleMarker(`\${${item[0]}}`, SHARED)
     EXTERNALS.push(moduleName)
-    const exposeFilepath = normalizePath(path.resolve(item[1].import))
+    const exposeFilepath = normalizePath(resolve(item[1].import))
     EXPOSES_MAP.set(item[0], exposeFilepath)
     item[1].id = exposeFilepath
     moduleMap += `\n"${item[0]}":()=>{
@@ -114,7 +114,7 @@ export function prodExposePlugin(
         moduleCssFileMap.forEach((value, key) => {
           item.code = item.code.replace(
             `${DYNAMIC_LOADING_CSS_PREFIX}${key}`,
-            `./${path.basename(value)}`
+            `./${basename(value)}`
           )
         })
 
@@ -159,14 +159,14 @@ export function prodExposePlugin(
     const moduleCssFileMap = new Map()
 
     for (const file in bundle) {
-      if (path.extname(file) === '.css') {
+      if (extname(file) === '.css') {
         cssFileMap.set(getOriginalFileName(file), file)
       }
     }
 
     for (const file in bundle) {
       let name = getOriginalFileName(file)
-      if (cssFileMap.get(name) != null && path.extname(file) !== '.css') {
+      if (cssFileMap.get(name) != null && extname(file) !== '.css') {
         moduleCssFileMap.set(bundle[file].facadeModuleId, cssFileMap.get(name))
         continue
       }
@@ -195,7 +195,7 @@ export function prodExposePlugin(
     return moduleCssFileMap
 
     function getOriginalFileName(file: string): string {
-      return path.parse(path.parse(file).name).name
+      return parse(parse(file).name).name
     }
   }
 }

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -1,12 +1,12 @@
-import { RemotesConfig, VitePluginFederationOptions } from 'types'
+import type { RemotesConfig, VitePluginFederationOptions } from 'types'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
-import { AcornNode, TransformPluginContext } from 'rollup'
+import type { AcornNode, TransformPluginContext } from 'rollup'
 import { getModuleMarker, parseRemoteOptions, removeNonLetter } from '../utils'
 import { builderInfo, parsedOptions } from '../public'
-import * as path from 'path'
-import { PluginHooks } from '../../types/pluginHooks'
-import * as fs from 'fs'
+import { basename, dirname } from 'path'
+import type { PluginHooks } from '../../types/pluginHooks'
+import { readFileSync } from 'fs'
 
 export function prodRemotePlugin(
   options: VitePluginFederationOptions
@@ -114,7 +114,7 @@ export default {
                   sharedInfo[0]
                 )}':{get:()=>__federation_import('./${
                   sharedInfo[1].root ? `${sharedInfo[1].root[0]}/` : ''
-                }${path.basename(
+                }${basename(
                   this.getFileName(sharedInfo[1].emitFile)
                 )}'),import:${sharedInfo[1].import}${
                   sharedInfo[1].requiredVersion
@@ -133,8 +133,8 @@ export default {
           const federationId = (
             await this.resolve('@originjs/vite-plugin-federation')
           )?.id
-          const satisfyId = `${path.dirname(federationId!)}/satisfy.js`
-          return fs.readFileSync(satisfyId, { encoding: 'utf-8' })
+          const satisfyId = `${dirname(federationId!)}/satisfy.js`
+          return readFileSync(satisfyId, { encoding: 'utf-8' })
         }
       }
 
@@ -156,7 +156,7 @@ export default {
           for (const expose of parsedOptions.prodExpose) {
             code = code.replace(
               `\${__federation_expose_${expose[0]}}`,
-              `./${path.basename(this.getFileName(expose[1].emitFile))}`
+              `./${basename(this.getFileName(expose[1].emitFile))}`
             )
           }
           return code
@@ -171,7 +171,7 @@ export default {
             const obj = arr[1]
             let str = ''
             if (typeof obj === 'object') {
-              const fileName = `./${path.basename(
+              const fileName = `./${basename(
                 this.getFileName(obj.emitFile)
               )}`
               str += `metaGet: ()=> metaGet('${fileName}'), get:()=>webpackGet('${fileName}'), loaded:1`

--- a/packages/lib/src/public.ts
+++ b/packages/lib/src/public.ts
@@ -1,4 +1,4 @@
-import { ConfigTypeSet } from 'types'
+import type { ConfigTypeSet } from 'types'
 // for generateBundle Hook replace
 export const EXPOSES_MAP = new Map()
 export const SHARED = 'shared'

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ConfigTypeSet,
   Exposes,
   Remotes,
@@ -6,8 +6,8 @@ import {
   SharedRuntimeInfo,
   VitePluginFederationOptions
 } from '../../types'
-import * as path from 'path'
-import { PluginContext } from 'rollup'
+import { posix, parse } from 'path'
+import type { PluginContext } from 'rollup'
 
 export function findDependencies(
   this: PluginContext,
@@ -147,7 +147,7 @@ export function getModuleMarker(value: string, type?: string): string {
 }
 
 export function normalizePath(id: string): string {
-  return path.posix.normalize(id.replace(/\\/g, '/'))
+  return posix.normalize(id.replace(/\\/g, '/'))
 }
 
 export function isSameFilepath(src: string, dest: string): boolean {
@@ -156,8 +156,8 @@ export function isSameFilepath(src: string, dest: string): boolean {
   }
   src = normalizePath(src)
   dest = normalizePath(dest)
-  const srcExt = path.parse(src).ext
-  const destExt = path.parse(dest).ext
+  const srcExt = parse(src).ext
+  const destExt = parse(dest).ext
   if (srcExt && destExt && srcExt !== destExt) {
     return false
   }

--- a/packages/lib/src/utils/semver/index.ts
+++ b/packages/lib/src/utils/semver/index.ts
@@ -10,7 +10,8 @@ import {
   parseStar,
   parseGTE0
 } from './parser'
-import { compare, CompareAtom } from './compare'
+import { compare } from './compare'
+import type { CompareAtom } from './compare'
 
 function parseComparatorString(range: string): string {
   return pipe(


### PR DESCRIPTION
Vite's `mode` used to detach `Env Variable` but not development or production. 
So, add `registerPlugins` `command` support
details: https://vitejs.dev/guide/env-and-mode.html 

BTW, chore some typescript type import