### PR TITLE
optimize: overwrite the expose's id to synchronize with building context

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -27,7 +27,6 @@ export function prodExposePlugin(
     EXTERNALS.push(moduleName)
     const exposeFilepath = normalizePath(resolve(item[1].import))
     EXPOSES_MAP.set(item[0], exposeFilepath)
-    item[1].id = exposeFilepath
     moduleMap += `\n"${item[0]}":()=>{
       ${DYNAMIC_LOADING_CSS}('${DYNAMIC_LOADING_CSS_PREFIX}${exposeFilepath}')
       return __federation_import('\${__federation_expose_${item[0]}}').then(module=>()=>module?.default??module)

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -165,6 +165,25 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
       if (builderInfo.isRemote) {
         for (const expose of parsedOptions.prodExpose) {
           if (!expose[1].emitFile) {
+            const resolveId = await this.resolve(expose[1].id)
+            if (resolveId && resolveId.id) {
+              /**
+               * overwrite the id with rollup resolved
+               * in rollup building context, rather than vite,
+               * the id of a module is using backslash(\) instead of slash(/) in windows os
+               * e.g.
+               * perhaps an expose's id is: 
+               * /path/to/a/module
+               * 
+               * will be resolved to:
+               * \path\to\a\module
+               * 
+               * it will break down some logic which rely on the this like #152
+               * 
+               * so overwrite here ensure that the id of expose object is synchronized with building context(rollup or vite)
+               */
+              expose[1].id = resolveId.id
+            }
             expose[1].emitFile = this.emitFile({
               type: 'chunk',
               id: expose[1].id,

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -165,24 +165,9 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
       if (builderInfo.isRemote) {
         for (const expose of parsedOptions.prodExpose) {
           if (!expose[1].emitFile) {
-            const resolveId = await this.resolve(expose[1].id)
-            if (resolveId && resolveId.id) {
-              /**
-               * overwrite the id with rollup resolved
-               * in rollup building context, rather than vite,
-               * the id of a module is using backslash(\) instead of slash(/) in windows os
-               * e.g.
-               * perhaps an expose's id is: 
-               * /path/to/a/module
-               * 
-               * will be resolved to:
-               * \path\to\a\module
-               * 
-               * it will break down some logic which rely on the this like #152
-               * 
-               * so overwrite here ensure that the id of expose object is synchronized with building context(rollup or vite)
-               */
-              expose[1].id = resolveId.id
+            if (!expose[1].id) {
+              // resolved the moduleId here for the referrence somewhere else like #152
+              expose[1].id = (await this.resolve(expose[1].import))?.id
             }
             expose[1].emitFile = this.emitFile({
               type: 'chunk',


### PR DESCRIPTION
@ruleeeer hi
overwrite the id of parsedOptions.prodExpose with the one rollup resolved before exposed modules to be emited,
because of in rollup building context, rather than vite, the id of a module is using backslash(\\) instead of slash(/) in windows os

e.g.
`/path/to/a/module`
will be resolved to:
`\path\to\a\module`

this will cause some problems in finding modules like #152, so the overwriting here is ensuring the id in parsedOptions.prodExpose is synchronized with building context

[reproduction](https://github.com/originjs/vite-plugin-federation/tree/main/packages/examples/simple-react-esm)
try to build the remote-esm app(on windows os), and find out that the exposed button didn't call importShared function