### PR TITLE
fix: regexp of dynamic css matchs double quotes(")

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -131,7 +131,7 @@ export function prodExposePlugin(
           res.set(filename, bundle[name])
           return res
         }, new Map())
-        item.code = item.code.replace(new RegExp(`'${DYNAMIC_LOADING_CSS_PREFIX}[^']+'`, 'g'), str => {
+        item.code = item.code.replace(new RegExp(`(["'])${DYNAMIC_LOADING_CSS_PREFIX}.*?\\1`, 'g'), str => {
           // when build.cssCodeSplit: false, all files are aggregated into style.xxxxxxxx.css
           if (viteConfigResolved && !viteConfigResolved.build.cssCodeSplit) {
             if (cssBundlesMap.size) {

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -166,7 +166,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
         for (const expose of parsedOptions.prodExpose) {
           if (!expose[1].emitFile) {
             if (!expose[1].id) {
-              // resolved the moduleId here for the referrence somewhere else like #152
+              // resolved the moduleId here for the reference somewhere else like #152
               expose[1].id = (await this.resolve(expose[1].import))?.id
             }
             expose[1].emitFile = this.emitFile({


### PR DESCRIPTION
@ruleeeer hi!
the single quote in template of remote helper will be compiled to double quote when turn on the build.minify(=true), it made the building output lost some codes, so i change the reg exp to match double quote

[reproduction](https://github.com/Timehello/federation-test)
try to build the remote app with turning on build.minify, and you will find out that remoteEntry.js didn't import component's css
![image](https://user-images.githubusercontent.com/7313124/160069915-da1d7407-601a-4efc-897c-0533f5b03264.png)
