### PR TITLE
feat: enable dynamic remote loading

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -8,7 +8,12 @@ import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import type { AcornNode, TransformPluginContext } from 'rollup'
 import type { Hostname, ViteDevServer } from '../../types/viteDevServer'
-import { getModuleMarker, normalizePath, parseRemoteOptions } from '../utils'
+import {
+  createRemotesMap,
+  getModuleMarker,
+  normalizePath,
+  parseRemoteOptions
+} from '../utils'
 import { builderInfo, parsedOptions } from '../public'
 import type { PluginHooks } from '../../types/pluginHooks'
 
@@ -31,19 +36,13 @@ export function devRemotePlugin(
     name: 'originjs:remote-development',
     virtualFile: {
       __federation__: `
-const remotesMap = {
-  ${remotes
-    .map(
-      (remote) =>
-        `'${remote.id}':{url:'${remote.config.external[0]}',format:'${remote.config.format}',from:'${remote.config.from}'}`
-    )
-    .join(',\n  ')}
-};
-const loadJS = (url, fn) => {
+${createRemotesMap(remotes)}
+const loadJS = async (url, fn) => {
+  const resolvedUrl = typeof url === 'string' ? url : await url();
   const script = document.createElement('script')
   script.type = 'text/javascript';
   script.onload = fn;
-  script.src = url;
+  script.src = resolvedUrl;
   document.getElementsByTagName('head')[0].appendChild(script);
 }
 const scriptTypes = ['var'];
@@ -69,19 +68,22 @@ async function __federation_method_ensure(remoteId) {
           }
           resolve(remote.lib);
         }
-        loadJS(remote.url, callback);
+        return loadJS(remote.url, callback);
       });
     } else if (importTypes.includes(remote.format)) {
       // loading js with import(...)
       return new Promise(resolve => {
-        import(/* @vite-ignore */ remote.url).then(lib => {
-          if (!remote.inited) {
-            lib.init(shareScope);
-            remote.lib = lib;
-            remote.lib.init(shareScope);
-            remote.inited = true;
-          }
-          resolve(remote.lib);
+        const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
+        getUrl().then(url => {
+          import(/* @vite-ignore */ url).then(lib => {
+            if (!remote.inited) {
+              lib.init(shareScope);
+              remote.lib = lib;
+              remote.lib.init(shareScope);
+              remote.inited = true;
+            }
+            resolve(remote.lib);
+          })
         })
       })
     }
@@ -258,7 +260,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
 
         if (requiresRuntime) {
           magicString.prepend(
-                `import {__federation_method_ensure, __federation_method_getRemote , __federation_method_wrapDefault , __federation_method_unwrapDefault} from '__federation__';\n\n`
+            `import {__federation_method_ensure, __federation_method_getRemote , __federation_method_wrapDefault , __federation_method_unwrapDefault} from '__federation__';\n\n`
           )
         }
         return {

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -38,7 +38,7 @@ export function devRemotePlugin(
       __federation__: `
 ${createRemotesMap(remotes)}
 const loadJS = async (url, fn) => {
-  const resolvedUrl = typeof url === 'string' ? url : await url();
+  const resolvedUrl = typeof url === 'function' ? await url() : url;
   const script = document.createElement('script')
   script.type = 'text/javascript';
   script.onload = fn;

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -38,7 +38,7 @@ export function prodRemotePlugin(
       __federation__: `
 ${createRemotesMap(remotes)}
 const loadJS = async (url, fn) => {
-  const resolvedUrl = typeof url === 'string' ? url : await url();
+  const resolvedUrl = typeof url === 'function' ? await url() : url;
   const script = document.createElement('script')
   script.type = 'text/javascript';
   script.onload = fn;

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -176,7 +176,7 @@ export function isSameFilepath(src: string, dest: string): boolean {
 
 export type Remote = { id: string; regexp: RegExp; config: RemotesConfig }
 
-export const createRemotesMap = (remotes: Remote[]) => {
+export function createRemotesMap(remotes: Remote[]): string {
   const createUrl = (remote: Remote) => {
     const external = remote.config.external[0]
     if (external.startsWith('promise ')) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Example implementation of #157 

Adds ability to define dynamic remotes via `external: "promise new Promise(resolve => /* ... */)"` syntax.

Example:

```js
federation({
  remotes: {
    myRemote1: {
      external: "promise new Promise(resolve => resolve(window.remoteUrls.myRemote1))",
    },
    myRemote2: {
      external: 'promise fetch("/api/remotes/myRemote2").then(res => res.json()).then(({ url }) => url)',
    },
  },
})
```

### Additional context

I'm not sold on the API, I just based it off of Webpack's similar feature - albeit not the same, as this version does not require you to define the module shape as well (`get` / `init`).

Any suggestions as to what the API should be like, e.g.:

```js
federation({
  remotes: {
    myRemote1: {
      // just an example name, to demo this approach
      expression: "window.remoteUrls.myRemote1"
    },
    myRemote2: {
      promise: 'fetch("/api/remotes/myRemote2").then(res => res.json()).then(({ url }) => url)'
    },
  }
})
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.