### PR TITLE
fix: #161

### DIFF
--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -48,7 +48,7 @@ const loadJS = async (url, fn) => {
 const scriptTypes = ['var'];
 const importTypes = ['esm', 'systemjs']
 function get(name){
-  return __federation_import(name).then(module => ()=>module)
+  return __federation_import(name).then(module => ()=> { return Object.prototype.toString.call(module).indexOf('Module') > -1 && module.default ? module.default : module })
 }
 const shareScope = {
   ${getModuleMarker('shareScope')}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
@ruleeeer  Hi! I try to fix #161 by some modifies below:
1. use rollup resolve function to get the shared module path first, and use the original way as fallback
2. when getting the remote's module, try to return the 'default' field of module if it is "Module" type in the runtime(both dev and production mode)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I'm not sure if the handle of "Module" type make sense, but in the [reproduction](https://github.com/HeadFox/issue-161-vite-plugin-federation) case, the react lib is really wrapped in the "default" field of module

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.