### PR TITLE
Fix  #161

### DIFF
--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -195,3 +195,5 @@ ${remotes
   .join(',\n  ')}
 };`
 }
+
+export const REMOTE_FROM_PARAMETER = 'remoteFrom'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
@ruleeeer Hi, I try to fix #161 via some modifies below:
1. In development mode, use rollup resolve function to get the shared module path first, and use the original way as fallback
2. Modify the getter of shared, if remote is from webpack, the getter will try to expose the content under the "default" field of an esm module, because webpack looks like didn't handle esm like module in share container( If not, please let me know :-) )

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
[reproduction](https://github.com/HeadFox/issue-161-vite-plugin-federation)
reproduct steps:
1. Serve the "webpack-remote-project"
2. Run dev command of "vite-host-project"

You will  see the remote module be not resolved

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.