### PR TITLE
fix: vite 2.9.0 causes manualChunks failed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm run lint-staged --workspace-concurrency false
+pnpm run lint-staged

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   },
   "lint-staged": {
     "*.{ts,js,json,tsx,jsx,vue}": [
-      "eslint",
+      "prettier --write",
       "eslint --cache --fix",
-      "prettier --write"
+      "eslint"
     ]
   }
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -148,7 +148,6 @@ export default function federation(
     },
 
     outputOptions(outputOptions) {
-      outputOptions.manualChunks = outputOptions.manualChunks || {}
       for (const pluginHook of pluginList) {
         pluginHook.outputOptions?.call(this, outputOptions)
       }


### PR DESCRIPTION
vite 2.9.0 updated the default `manualChunks` behavior, which caused the plugin to potentially cause shared processing to fail when used with vite 2.9.0 and above, this PR fixes the issue at vite 2.9.0 and above
<br>

![image](https://user-images.githubusercontent.com/70385062/167401442-2fa8fe03-e691-47e2-8a5b-a5a66a6887c0.png)

close #178 