### PR TITLE
fix: update content hash calculate for export modules

### DIFF
--- a/packages/lib/src/public.ts
+++ b/packages/lib/src/public.ts
@@ -1,6 +1,7 @@
 import type { ConfigTypeSet } from 'types'
 // for generateBundle Hook replace
 export const EXPOSES_MAP = new Map()
+export const EXPOSES_KEY_MAP = new Map()
 export const SHARED = 'shared'
 export const DYNAMIC_LOADING_CSS = 'dynamicLoadingCss'
 export const DYNAMIC_LOADING_CSS_PREFIX = '__v__css__'

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -78,15 +78,6 @@ export function createContentHash(path: string): string {
   return createHash('md5').update(content).digest('hex').toString().slice(0, 8)
 }
 
-const nameCharReg = new RegExp('[0-9a-zA-Z@_-]+')
-export function getExposeImportName(item: string | ConfigTypeSet): string {
-  if (typeof item === 'string') {
-    return item
-  }
-
-  return `${removeNonRegLetter(item[0], nameCharReg)}_${item[1].contentHash}`
-}
-
 export function parseRemoteOptions(
   options: VitePluginFederationOptions
 ): (string | ConfigTypeSet)[] {
@@ -219,3 +210,4 @@ ${remotes
 }
 
 export const REMOTE_FROM_PARAMETER = 'remoteFrom'
+export const NAME_CHAR_REG = new RegExp('[0-9a-zA-Z@_-]+')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #216 
Here is a pr for content hash calculate for export modules,  i update the calculate way by depend to rollup which can config the `outputh.chunkFileNames` to generate the filename rule for chunk automatically

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.