### PR TITLE
fix: importShared is not a function

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -87,7 +87,7 @@ export function prodSharedPlugin(
                       node.end,
                       `const {${declaration.join(
                         ','
-                      )}} = await importShared('${sharedName}')\n`
+                      )}} = await importShared('${sharedName}');\n`
                     )
                     modify = true
                   }
@@ -100,7 +100,7 @@ export function prodSharedPlugin(
             magicString.prepend(
               `import {importShared} from '${
                 prop?.root ? '.' : ''
-              }./__federation_fn_import.js'\n`
+              }./__federation_fn_import.js';\n`
             )
             return {
               code: magicString.toString(),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For some reasons, after build, I received the `index.<hash>.js` file content like this one

```
import {importShared} from './__federation_fn_import.js'
const {default:I,r:d} = await importShared('react')
const {r:be} = await importShared('react-dom')
const {j:u,a:O,F:Ce,useLocation:K,matchRoutes:xe,Outlet:Pe,Navigate:Oe,useNavigate:qe,Routes:Se,Route:L,BrowserRouter:Ae} = await importShared('react-router-dom')
import{P as Fe,a as Me,t as De,F as Re,L as se,A as we,R as Ie,d as re,r as Qe,n as x,b as Ee,g as Te,c as $e,e as v,i as _,f as _e,S as ie,h as ne,p as S,m as j,M as Ue,j as V,k as W,o as z,l as Le,q as U,s as w,u as G,v as ke,w as Ke,x as Be,y as Ne,z as Z,B as He,C as je,D as Ve,Q as We,App as ze}from"./__federation_expose_App.7d6c791a.js";const {u:Ge,a:J,b:Ze,m:Je,chakra:ae,A:Xe,Alert:Ye,AlertIcon:et,AlertTitle:tt,AlertDescription:st,CloseButton:rt,ThemeProvider:it,ColorModeProvider:nt,CSSReset:at,CSSPolyfill:ot,GlobalStyle:ut,EnvironmentProvider:lt,theme:ct,extendTheme:oe,Box:Q,Flex:B,Heading:ue,Stack:k,Divider:ht} = await importShared('@chakra-ui/react')
(function(){const e=document.createElement("link").relList;if(e&&e.supports&&e.supports("modulepreload"))return;for(const r of document.
```

Without semicolon at the end of `importShared('@chakra-ui/react')` will make js think the code will be like this

```
const {
  u: Ge,
  a: J,
  b: Ze,
  m: Je,
  chakra: ae,
  A: Xe,
  Alert: Ye,
  AlertIcon: et,
  AlertTitle: tt,
  AlertDescription: st,
  CloseButton: rt,
  ThemeProvider: it,
  ColorModeProvider: nt,
  CSSReset: at,
  CSSPolyfill: ot,
  GlobalStyle: ut,
  EnvironmentProvider: lt,
  theme: ct,
  extendTheme: oe,
  Box: Q,
  Flex: B,
  Heading: ue,
  Stack: k,
  Divider: ht,
} = await importShared('@chakra-ui/react')(function () {
  const e = document.createElement('link').relList;
 // other codes
}
```

Then when running the code, it will raise error `Uncaught TypeError: importShared(...) is not a function`

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.