### PR TITLE
feat(resolveHostname) resolve host name and respect server.origin

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -343,7 +343,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
     shared: (string | ConfigTypeSet)[],
     viteVersion: string | undefined
   ): Promise<string[]> {
-    const hostname = resolveHostname(viteDevServer.config.server.host)
+    const hostname = resolveHostname(viteDevServer.config.server)
     const protocol = viteDevServer.config.server.https ? 'https' : 'http'
     const port = viteDevServer.config.server.port ?? 5000
     const regExp = new RegExp(
@@ -388,9 +388,11 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
     return res
   }
 
-  function resolveHostname(
-    optionsHost: string | boolean | undefined
-  ): Hostname {
+  function resolveHostname(serverOptions): Hostname {
+    const optionsHost = serverOptions.host
+    const optionOrigin = serverOptions.origin
+    // could be destructured
+
     let host: string | undefined
     if (
       optionsHost === undefined ||
@@ -406,14 +408,25 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
       host = optionsHost
     }
 
-    // Set host name to localhost when possible, unless the user explicitly asked for '127.0.0.1'
-    const name =
-      (optionsHost !== '127.0.0.1' && host === '127.0.0.1') ||
+    // Set host name to origin hostname or to localhost when possible, unless the user explicitly asked for '127.0.0.1'
+    let name;
+    if (optionOrigin) {
+       // Keep hostname from url
+        if (optionOrigin.includes('://')) {
+          const [, hostname] = optionOrigin.split('://')
+          name = hostname
+        } else {
+          name = optionOrigin
+        }
+    } else if ((optionsHost !== '127.0.0.1' && host === '127.0.0.1') ||
       host === '0.0.0.0' ||
       host === '::' ||
       host === undefined
-        ? 'localhost'
-        : host
+    ) {
+      name = 'localhost'
+    } else {
+      name = host
+    }
 
     return { host, name }
   }


### PR DESCRIPTION
As a developper and during development, i need vite-plugin-federation resolve my specific host origin set on vite configuration server.origin  Use it or try to set localhost.

### Description

In a specific configuration (dnsmasq & docker) to reproduce "real" production state, i wasnt able to define a different hostname for our .cacheDir path, after looking into the repo code, find that we can use origin option from vite config server.

### Additional context

This PR is an open discussion first, i am not sure server.origin in this way is the best solution, but let's discuss on it.!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.