### PR TITLE
fix isHost

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -346,8 +346,8 @@ export function prodSharedPlugin(
       `
     },
     options(inputOptions) {
-      isHost = !!parsedOptions.prodRemote.length
       isRemote = !!parsedOptions.prodExpose.length
+      isHost = !!parsedOptions.prodRemote.length && !isRemote
 
       if (shareName2Prop.size) {
         // remove item which is both in external and shared


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When remote module has remotes and expose it will generate wrong shared imports and will double import same shared module. It will produce double instance. So this change will fix it

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.