### PR TITLE
fix: added catch when loading js with import(...)

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -96,7 +96,7 @@ async function __federation_method_ensure(remoteId) {
       });
     } else if (importTypes.includes(remote.format)) {
       // loading js with import(...)
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
         getUrl().then(url => {
           import(/* @vite-ignore */ url).then(lib => {
@@ -108,7 +108,7 @@ async function __federation_method_ensure(remoteId) {
               remote.inited = true;
             }
             resolve(remote.lib);
-          })
+          }).catch(reject)
         })
       })
     }

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -100,7 +100,7 @@ async function __federation_method_ensure(remoteId) {
       });
     } else if (importTypes.includes(remote.format)) {
       // loading js with import(...)
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
         getUrl().then(url => {
           import(/* @vite-ignore */ url).then(lib => {
@@ -112,7 +112,7 @@ async function __federation_method_ensure(remoteId) {
               remote.inited = true;
             }
             resolve(remote.lib);
-          })
+          }).catch(reject)
         })
       })
     }


### PR DESCRIPTION
### Description

When federated module fails to load, promise returned from import(...) is never rejected.
This PR allows to handle import errors in host application by using catch, and present errors to the user. 

This fixes #316.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other