### PR TITLE
fix default and named import case

### DIFF
--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -292,24 +292,32 @@ export function prodRemotePlugin(
                       defaultImportDeclaration = specify.local.name
                     }
                   })
+
                   hasImportShared = true
-                }
-                if (defaultImportDeclaration) {
-                  magicString.overwrite(
-                    node.start,
-                    node.end,
-                    `const ${defaultImportDeclaration} = await importShared('${moduleName}');\n`
-                  )
-                  hasImportShared = true
-                } else if (namedImportDeclaration.length) {
-                  magicString.overwrite(
-                    node.start,
-                    node.end,
-                    `const {${namedImportDeclaration.join(
-                      ','
-                    )}} = await importShared('${moduleName}');\n`
-                  )
-                  hasImportShared = true
+
+                  if (
+                    defaultImportDeclaration &&
+                    namedImportDeclaration.length
+                  ) {
+                    // import a, {b} from 'c' -> const a = await importShared('c'); const {b} = a;
+                    const imports = namedImportDeclaration.join(',')
+                    const line = `const ${defaultImportDeclaration} = await importShared('${moduleName}');\nconst {${imports}} = ${defaultImportDeclaration};\n`
+                    magicString.overwrite(node.start, node.end, line)
+                  } else if (defaultImportDeclaration) {
+                    magicString.overwrite(
+                      node.start,
+                      node.end,
+                      `const ${defaultImportDeclaration} = await importShared('${moduleName}');\n`
+                    )
+                  } else if (namedImportDeclaration.length) {
+                    magicString.overwrite(
+                      node.start,
+                      node.end,
+                      `const {${namedImportDeclaration.join(
+                        ','
+                      )}} = await importShared('${moduleName}');\n`
+                    )
+                  }
                 }
               }
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Solves the default + named import case, i.e.
```ts
import React, {useState} from 'react
```

https://github.com/originjs/vite-plugin-federation/issues/294

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.