### PR TITLE
fix: generate correct source_map when use remote code

### DIFF
--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -455,7 +455,10 @@ export function prodRemotePlugin(
         }
 
         if (requiresRuntime || hasImportShared || modify) {
-          return magicString.toString()
+          return {
+            code: magicString.toString(),
+            map: magicString.generateMap({ hires: true })
+          };
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`fix #355`
generate correct source_map when use remote code.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other