### PR TITLE
fix: systemjs dynamically import error

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -96,7 +96,10 @@ async function __federation_method_ensure(remoteId) {
       return new Promise((resolve, reject) => {
         const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
         getUrl().then(url => {
-          import(/* @vite-ignore */ url).then(lib => {
+          const importer = remote.format === 'systemjs'
+            ? System.import(/* @vite-ignore */ url)
+            : import(/* @vite-ignore */ url)
+          importer.then(lib => {
             if (!remote.inited) {
               const shareScope = wrapShareScope(remote.from)
               lib.init(shareScope);
@@ -125,7 +128,7 @@ function __federation_method_wrapDefault(module ,need){
     obj.__esModule = true;
     return obj;
   }
-  return module; 
+  return module;
 }
 
 function __federation_method_getRemote(remoteName,  componentName){

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -105,7 +105,10 @@ export function prodRemotePlugin(
                             return new Promise((resolve, reject) => {
                                 const getUrl = typeof remote.url === 'function' ? remote.url : () => Promise.resolve(remote.url);
                                 getUrl().then(url => {
-                                    import(/* @vite-ignore */ url).then(lib => {
+                                    const importer = remote.format === 'systemjs'
+                                      ? System.import(/* @vite-ignore */ url)
+                                      : import(/* @vite-ignore */ url)
+                                      importer.then(lib => {
                                         if (!remote.inited) {
                                             const shareScope = wrapShareModule(remote.from)
                                             lib.init(shareScope);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Plugin will get an error when importing a dynamical systemjs module, as [this issues ](https://github.com/originjs/vite-plugin-federation/issues/105) say
```
Uncaught (in promise) TypeError: remote.init is not a function
```

Because the plugin deals with `systemjs` as same as `esm`. but systemjs need to use `System.import` to import dynamic modules according to [systemjs readme](https://github.com/systemjs/systemjs), and I think it is better to add a hint: we need to manually import systemjs in the project when you need remotes systemjs format module. Thank you

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other