### PR TITLE
fix: dev mode error because of not js type related files

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -228,6 +228,10 @@ import myButton from 'remote/myButton'
 
 ### `filename：string`
 * 作为远程模块的入口文件，非必填，默认为`remoteEntry.js`
+ 
+### `transformFileTypes:string[]`
+* 插件所需要处理的文件类型，绝大多数情况下无需配置，因为默认设置了这些类型`['.js','.ts','.jsx','.tsx','.mjs','.cjs','.vue','.svelte']`，当你自定义了一些文件类型时并且需要`vite-plugin-federation`插件处理时，请把它添加到数组配置中。
+
 ### `exposes`
 
 * 作为远程模块，对外暴露的组件列表，远程模块必填。

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ Required as the module name of the remote module.
 
 ### `filename:string`
 As the entry file of the remote module, not required, default is `remoteEntry.js`
+
+### `transformFileTypes:string[]`
+* In most cases, the file types that the plug-in needs to process do not need to be configured, because these types are set by default.['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs', '.vue', '.svelte'],When you customize some file types and need the `vite-plugin-federation` plugin processing, please add it to the array configuration.
+
+
 ### `exposes`
 * As the remote module, the list of components exposed to the public, required for the remote module.
 ```js

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -26,6 +26,7 @@ import type { AcornNode, TransformPluginContext } from 'rollup'
 import type { Hostname, ViteDevServer } from '../../types/viteDevServer'
 import {
   createRemotesMap,
+  getFileExtname,
   getModuleMarker,
   normalizePath,
   parseRemoteOptions,
@@ -47,6 +48,20 @@ export function devRemotePlugin(
     })
   }
 
+  const needHandleFileType = [
+    '.js',
+    '.ts',
+    '.jsx',
+    '.tsx',
+    '.mjs',
+    '.cjs',
+    '.vue',
+    '.svelte'
+  ]
+  options.transformFileTypes = (options.transformFileTypes ?? [])
+    .concat(needHandleFileType)
+    .map((item) => item.toLowerCase())
+  const transformFileTypeSet = new Set(options.transformFileTypes)
   let viteDevServer: ViteDevServer
   return {
     name: 'originjs:remote-development',
@@ -181,6 +196,12 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
           parsedOptions.devShared
         )
         return code.replace(getModuleMarker('shareScope'), scopeCode.join(','))
+      }
+
+      // ignore some not need to handle file types
+      const fileExtname = getFileExtname(id)
+      if (!transformFileTypeSet.has((fileExtname ?? '').toLowerCase())) {
+        return
       }
 
       let ast: AcornNode | null = null

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -23,7 +23,7 @@ import type {
 } from '../../types'
 import { readFileSync } from 'fs'
 import { createHash } from 'crypto'
-import { parse, posix } from 'path'
+import path, { parse, posix } from 'path'
 import type { PluginContext } from 'rollup'
 
 export function findDependencies(
@@ -186,6 +186,10 @@ export function normalizePath(id: string): string {
   return posix.normalize(id.replace(/\\/g, '/'))
 }
 
+export function uniqueArr<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr))
+}
+
 export function isSameFilepath(src: string, dest: string): boolean {
   if (!src || !dest) {
     return false
@@ -228,6 +232,17 @@ ${remotes
   )
   .join(',\n  ')}
 };`
+}
+
+/**
+ * get file extname from url
+ * @param url
+ */
+export function getFileExtname(url: string): string {
+  const fileNameAndParamArr = normalizePath(url).split('/')
+  const fileNameAndParam = fileNameAndParamArr[fileNameAndParamArr.length - 1]
+  const fileName = fileNameAndParam.split('?')[0]
+  return path.extname(fileName)
 }
 
 export const REMOTE_FROM_PARAMETER = 'remoteFrom'

--- a/packages/lib/types/index.d.ts
+++ b/packages/lib/types/index.d.ts
@@ -18,6 +18,12 @@ declare interface VitePluginFederationOptions {
   filename?: string
 
   /**
+   * transform hook need to handle file types
+   * default ['.js','.ts','.jsx','.tsx','.mjs','.cjs','.vue','.svelte']
+   */
+  transformFileTypes?: string[]
+
+  /**
    * Options for library.
    */
   // library?: LibraryOptions


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix dev mode error because the ast parse occurred for non-js-related file types.
Now transform hook will only process the following types of files by default.
`['.js','.ts','.jsx','.tsx','.mjs','.cjs','.vue','.svelte']`

If you need to deal with other types, you can add other types to the federation configuration to support it like follow
``` js
federation({
      transformFileTypes:['.myCustomized']
})
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/originjs/vite-plugin-federation/blob/main/CONTRIBUTING.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.