### PR TITLE
fix: vite --mode always overrides configured mode

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -105,7 +105,7 @@ export default function federation(
       return _options
     },
     config(config: UserConfig, env: ConfigEnv) {
-      options.mode = env.mode
+      options.mode = options.mode ?? env.mode
       registerPlugins(options.mode, env.command)
       registerCount++
       for (const pluginHook of pluginList) {


### PR DESCRIPTION
Currently vite mode is always overriding plugin configuration.

Changed to use configured mode, and if absent default to vite mode.

### Description

fix for originjs/vite-plugin-federation#404

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
