### PR TITLE
dev mode, running host without localhost cause remote importing shared failed V2

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -364,8 +364,6 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
     shared: (string | ConfigTypeSet)[]
   ): Promise<string[]> {
     const serverConfiguration = viteDevServer.config.server
-    const protocol = serverConfiguration.https ? 'https' : 'http'
-    const port = serverConfiguration.port ?? 5173
     const res: string[] = []
     if (shared.length) {
       const cwdPath = normalizePath(process.cwd())
@@ -387,32 +385,16 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
         const obj = item[1]
         let str = ''
         if (typeof obj === 'object') {
-          const address =
-            serverConfiguration.origin ??
-            `${protocol}://${resolveHost(serverConfiguration)}:${port}`
-          const url = relativePath
-            ? `'${address}${relativePath}'`
-            : `'${address}/@fs/${moduleInfo.id}'`
+          const origin = serverConfiguration.origin
+          const pathname = relativePath ?? `/@fs/${moduleInfo.id}`
+          const url = origin
+            ? `'${origin}${pathname}'`
+            : `window.location.origin+'${pathname}'`
           str += `get:()=> get(${url}, ${REMOTE_FROM_PARAMETER})`
           res.push(`'${sharedName}':{'${obj.version}':{${str}}}`)
         }
       }
     }
     return res
-  }
-
-  function resolveHost(serverOptions): string {
-    const hostConfiguration = serverOptions.host
-    let host: string
-    //
-    if (
-      hostConfiguration === undefined ||
-      typeof hostConfiguration === 'boolean'
-    ) {
-      host = 'localhost'
-    } else {
-      host = hostConfiguration
-    }
-    return host
   }
 }


### PR DESCRIPTION
dev mode, running host without localhost cause remote importing shared failed


<!-- Thank you for contributing! -->

### Description
Dev mode, if hosting without **host**, but ip like **192.168.1.XX**, 
shared address generated in virtual file `virtual:__federation__` will be something like
```js
  return {
    'shared-lib':{'undefined':{get:()=> get('http://localhost:port/node_modules/shared-lib.js', remoteFrom)}}
  }
}
```
The host is hard coded to **localhost**, which will cause the remote importing shared failed

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Describe alternatives you've considered
```js
get('http://localhost:port/node_modules/shared-lib.js
```
changes to
```js
get(window.location.origin+'/node_modules/shared-lib.js
```
