### PR TITLE
fix: improve getSharedFromXXX detect need unwrap module V2

### DIFF
--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -32,7 +32,8 @@ async function getSharedFromRuntime(name, shareScope) {
     }
   }
   if (module) {
-    if (module.default) module = module.default
+    if (module.default && Object.keys(module).length < 2)
+      module = module.default
     moduleCache[name] = module
     return module
   }
@@ -40,7 +41,8 @@ async function getSharedFromRuntime(name, shareScope) {
 async function getSharedFromLocal(name) {
   if (moduleMap[name]?.import) {
     let module = await (await moduleMap[name].get())()
-    if (module.default) module = module.default
+    if (module.default && Object.keys(module).length < 2)
+      module = module.default
     moduleCache[name] = module
     return module
   } else {


### PR DESCRIPTION
[issue link](https://github.com/originjs/vite-plugin-federation/issues/413)

update:

```ts
if (module.default)
  module = module.default
```
to
```ts
if (module.default && Object.keys(module).length < 2)
  module = module.default
```