### PR TITLE
feat: 插件支持多个federation配置

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -61,8 +61,9 @@ export function devRemotePlugin(
   let viteDevServer: ViteDevServer
   return {
     name: 'originjs:remote-development',
-    virtualFile: {
-      [`__federation__${options.filename}`]: `
+    virtualFile: options.remotes
+      ? {
+          __federation__: `
 ${createRemotesMap(devRemotes)}
 const loadJS = async (url, fn) => {
   const resolvedUrl = typeof url === 'function' ? await url() : url;
@@ -144,7 +145,8 @@ function __federation_method_getRemote(remoteName,  componentName){
 }
 export {__federation_method_ensure, __federation_method_getRemote , __federation_method_unwrapDefault , __federation_method_wrapDefault}
 ;`
-    },
+        }
+      : { __federation__: '' },
     config(config: UserConfig) {
       // need to include remotes in the optimizeDeps.exclude
       if (parsedOptions.devRemote.length) {
@@ -186,7 +188,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
         }
       }
 
-      if (id === `\0virtual:__federation__${options.filename}`) {
+      if (id === '\0virtual:__federation__') {
         const scopeCode = await devSharedScopeCode.call(
           this,
           parsedOptions.devShared
@@ -348,7 +350,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
 
       if (requiresRuntime) {
         magicString.prepend(
-          `import {__federation_method_ensure, __federation_method_getRemote , __federation_method_wrapDefault , __federation_method_unwrapDefault} from '__federation__${options.filename}';\n\n`
+          `import {__federation_method_ensure, __federation_method_getRemote , __federation_method_wrapDefault , __federation_method_unwrapDefault} from '__federation__';\n\n`
         )
       }
       return magicString.toString()

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -32,16 +32,16 @@ import {
   parseRemoteOptions,
   REMOTE_FROM_PARAMETER
 } from '../utils'
-import { builderInfo, parsedOptions } from '../public'
+import { builderInfo, parsedOptions, devRemotes } from '../public'
 import type { PluginHooks } from '../../types/pluginHooks'
 
 export function devRemotePlugin(
   options: VitePluginFederationOptions
 ): PluginHooks {
   parsedOptions.devRemote = parseRemoteOptions(options)
-  const remotes: { id: string; regexp: RegExp; config: RemotesConfig }[] = []
+  // const remotes: { id: string; regexp: RegExp; config: RemotesConfig }[] = []
   for (const item of parsedOptions.devRemote) {
-    remotes.push({
+    devRemotes.push({
       id: item[0],
       regexp: new RegExp(`^${item[0]}/.+?`),
       config: item[1]
@@ -67,7 +67,7 @@ export function devRemotePlugin(
     name: 'originjs:remote-development',
     virtualFile: {
       __federation__: `
-${createRemotesMap(remotes)}
+${createRemotesMap(devRemotes)}
 const loadJS = async (url, fn) => {
   const resolvedUrl = typeof url === 'function' ? await url() : url;
   const script = document.createElement('script')
@@ -227,7 +227,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
             node.source?.value?.indexOf('/') > -1
           ) {
             const moduleId = node.source.value
-            const remote = remotes.find((r) => r.regexp.test(moduleId))
+            const remote = devRemotes.find((r) => r.regexp.test(moduleId))
             const needWrap = remote?.config.from === 'vite'
             if (remote) {
               requiresRuntime = true

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -14,11 +14,7 @@
 // *****************************************************************************
 
 import type { UserConfig } from 'vite'
-import type {
-  ConfigTypeSet,
-  RemotesConfig,
-  VitePluginFederationOptions
-} from 'types'
+import type { ConfigTypeSet, VitePluginFederationOptions } from 'types'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { readFileSync } from 'fs'
@@ -66,7 +62,7 @@ export function devRemotePlugin(
   return {
     name: 'originjs:remote-development',
     virtualFile: {
-      __federation__: `
+      [`__federation__${options.filename}`]: `
 ${createRemotesMap(devRemotes)}
 const loadJS = async (url, fn) => {
   const resolvedUrl = typeof url === 'function' ? await url() : url;
@@ -190,7 +186,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
         }
       }
 
-      if (id === '\0virtual:__federation__') {
+      if (id === `\0virtual:__federation__${options.filename}`) {
         const scopeCode = await devSharedScopeCode.call(
           this,
           parsedOptions.devShared
@@ -352,7 +348,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
 
       if (requiresRuntime) {
         magicString.prepend(
-          `import {__federation_method_ensure, __federation_method_getRemote , __federation_method_wrapDefault , __federation_method_unwrapDefault} from '__federation__';\n\n`
+          `import {__federation_method_ensure, __federation_method_getRemote , __federation_method_wrapDefault , __federation_method_unwrapDefault} from '__federation__${options.filename}';\n\n`
         )
       }
       return magicString.toString()

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -46,15 +46,17 @@ export default function federation(
 
   function registerPlugins(mode: string, command: string) {
     if (mode === 'development' || command === 'serve') {
-      pluginList = [devSharedPlugin(options), devExposePlugin(options)]
-      if (options.remotes) {
-        pluginList.push(devRemotePlugin(options))
-      }
+      pluginList = [
+        devSharedPlugin(options),
+        devExposePlugin(options),
+        devRemotePlugin(options)
+      ]
     } else if (mode === 'production' || command === 'build') {
-      pluginList = [prodSharedPlugin(options), prodExposePlugin(options)]
-      if (options.remotes) {
-        pluginList.push(prodRemotePlugin(options))
-      }
+      pluginList = [
+        prodSharedPlugin(options),
+        prodExposePlugin(options),
+        prodRemotePlugin(options)
+      ]
     } else {
       pluginList = []
     }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -46,17 +46,15 @@ export default function federation(
 
   function registerPlugins(mode: string, command: string) {
     if (mode === 'development' || command === 'serve') {
-      pluginList = [
-        devSharedPlugin(options),
-        devExposePlugin(options),
-        devRemotePlugin(options)
-      ]
+      pluginList = [devSharedPlugin(options), devExposePlugin(options)]
+      if (options.remotes) {
+        pluginList.push(devRemotePlugin(options))
+      }
     } else if (mode === 'production' || command === 'build') {
-      pluginList = [
-        prodSharedPlugin(options),
-        prodExposePlugin(options),
-        prodRemotePlugin(options)
-      ]
+      pluginList = [prodSharedPlugin(options), prodExposePlugin(options)]
+      if (options.remotes) {
+        pluginList.push(prodRemotePlugin(options))
+      }
     } else {
       pluginList = []
     }

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -23,9 +23,15 @@ import {
   parseRemoteOptions,
   removeNonRegLetter,
   REMOTE_FROM_PARAMETER,
-  NAME_CHAR_REG
+  NAME_CHAR_REG,
+  createContentHash
 } from '../utils'
-import { builderInfo, EXPOSES_KEY_MAP, parsedOptions, prodRemotes } from '../public'
+import {
+  builderInfo,
+  EXPOSES_KEY_MAP,
+  parsedOptions,
+  prodRemotes
+} from '../public'
 import { basename } from 'path'
 import type { PluginHooks } from '../../types/pluginHooks'
 
@@ -157,7 +163,7 @@ export function prodRemotePlugin(
             const basename = `__federation_shared_${removeNonRegLetter(
               sharedInfo[0],
               NAME_CHAR_REG
-            )}.js`
+            )}-${createContentHash(sharedInfo[1].packagePath)}.js`
             sharedInfo[1].emitFile = this.emitFile({
               type: 'chunk',
               id: sharedInfo[1].id ?? sharedInfo[1].packagePath,

--- a/packages/lib/src/public.ts
+++ b/packages/lib/src/public.ts
@@ -13,7 +13,9 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // *****************************************************************************
 
-import type { ConfigTypeSet } from 'types'
+import type { ConfigTypeSet, RemotesConfig } from 'types'
+import type { ResolvedConfig } from 'vite'
+import { Remote } from './utils'
 // for generateBundle Hook replace
 export const EXPOSES_MAP = new Map()
 export const EXPOSES_KEY_MAP = new Map()
@@ -40,3 +42,6 @@ export const parsedOptions = {
   devExpose: [] as (string | ConfigTypeSet)[],
   devRemote: [] as (string | ConfigTypeSet)[]
 }
+export const devRemotes: { id: string; regexp: RegExp; config: RemotesConfig }[] = []
+export const prodRemotes: Remote[] = []
+export const viteConfigResolved: { config: ResolvedConfig | undefined } = { config: undefined };


### PR DESCRIPTION
### Description

插件很好用，能满足从远程读取页面或者插件的能力。我们目前项目非常的大，**每次打包都会花费非常非常多的时间**，因此我们就想引入此插件来优化打包时间，我们的想法是，**第一次打包时**，将页面和部分组件都打成federation包，同时把引用这些包的地方都改为远程引入地址。这样当我们之后只改动页面或者组件时，我们只需要打包这一部分包就可以**实现按需打包**，大大的降低打包时间。可惜的是此插件不支持这个能力，因为支持这个能力的条件是能有多个federation配置（因为项目必须得同时导出和引入，且有多个exposes配置，之后打包时按需执行其中某一个exposes），所以基于此需求，我对此插件进行了一些修改，可以使其满足这个需求。
**多federation配置项目演示：**
https://github.com/amazingywk/vite-multiple-federation-example
![image](https://github.com/originjs/vite-plugin-federation/assets/74231206/26a7dca7-85fb-4835-ad5c-8a3fc405a9d4)
注：因为必须得打成包才可以使用，这里可以看到我把它打成了自己的包@amazingywk/vite-plugin-federation@1.0.1，这个包的代码与我提的此pr代码一致

### Additional context

**不能写多个包含remotes的federation配置**
![image](https://github.com/originjs/vite-plugin-federation/assets/74231206/e2121c37-128e-47c0-9eae-627ec1ad1e39)
尽管我已经尽力满足了可以写多个federation配置，但仍然还有这一个小问题没有解决，但是在我看来，这个问题是允许存在的，也不会有很大的影响，且以我的能力（刚工作一年的菜鸟）看来这个问题想要修改可能会导致很多逻辑的重构。也希望大大们后续可以解决这个问题，感谢

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
