### PR TITLE
fix: stop reading server configuration when no shared

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -363,9 +363,9 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
     this: TransformPluginContext,
     shared: (string | ConfigTypeSet)[]
   ): Promise<string[]> {
-    const serverConfiguration = viteDevServer.config.server
     const res: string[] = []
     if (shared.length) {
+      const serverConfiguration = viteDevServer.config.server
       const cwdPath = normalizePath(process.cwd())
 
       for (const item of shared) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Stop reading server configuration when no shared on configuration

### Additional context

When we launch build in development mode, the code tries to read the configuration of the development Vite server, but there is no such configuration, producing an error because configureServer is not called in this mode.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
