### PR TITLE
feat: dynamic loading of remote support

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -146,7 +146,11 @@ function __federation_method_wrapDefault(module ,need){
 function __federation_method_getRemote(remoteName,  componentName){
   return __federation_method_ensure(remoteName).then((remote) => remote.get(componentName).then(factory => factory()));
 }
-export {__federation_method_ensure, __federation_method_getRemote , __federation_method_unwrapDefault , __federation_method_wrapDefault}
+
+function __federation_method_setRemote(remoteName, remoteConfig) {
+  remotesMap[remoteName] = remoteConfig;
+}
+export {__federation_method_ensure, __federation_method_getRemote , __federation_method_setRemote , __federation_method_unwrapDefault , __federation_method_wrapDefault}
 ;`
     },
     config(config: UserConfig) {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -149,6 +149,12 @@ export default function federation(
         )?.id
         return await this.resolve(`${dirname(federationId!)}/satisfy.mjs`)
       }
+      if (args[0] === 'virtual:__federation__') {
+        return {
+          id: '\0virtual:__federation__',
+          moduleSideEffects: true
+        }
+      }
       return null
     },
 

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -141,9 +141,14 @@ export function prodRemotePlugin(
                     return __federation_method_ensure(remoteName).then((remote) => remote.get(componentName).then(factory => factory()));
                 }
 
+                function __federation_method_setRemote(remoteName, remoteConfig) {
+                  remotesMap[remoteName] = remoteConfig;
+                }
+
                 export {
                     __federation_method_ensure,
                     __federation_method_getRemote,
+                    __federation_method_setRemote,
                     __federation_method_unwrapDefault,
                     __federation_method_wrapDefault
                 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This commit exposes the virtual module 'virtual:__federation__' inside the plugin to the outside. The setRemote method is a reference to [poc of dynamic remote](https://github.com/foot/vite-plugin-federation/pull/1) method.
这个提交暴露出了插件内置的虚拟模块'virtual:__federation__'。基于 [foot](https://github.com/foot) 提出的 [poc of dynamic remote](https://github.com/foot/vite-plugin-federation/pull/1)，在虚拟模块内部增加了setRemote方法。

webpack moduleFederation dynamic remote simple demo
```js
async loadModule(scope, module) { // scope='home', module='./Content'
      await __webpack_init_sharing__('default');
      const container = window[scope];
      await container.init(__webpack_share_scopes__.default);
      const factory = await window[scope].get(module);
      const Module = factory();
      return Module;
    }
```
vite-plugin-federation dynamic renote simple demo after my change
```js
async function loadModule(remote) { // remote = { id:'moduleId',url:'http://localhost:xxx/',formate:'esm',from:'vite' }
  __federation_method_setRemote(remote.id, {
    url: () => Promise.resolve(remote.url),
    format: remote.format,
    from: remote.from,
  });
  const factory = async () =>
    __federation_method_getRemote(remote.id, "./module-init").then((module) =>
      __federation_method_wrapDefault(module, true)
    );
  const module = await factory()
  return module;
}
```

### Additional context

The code submitted this time does not modify the original logic, only opens external calls, so there is no need to worry about affecting the project. (Unless the virtual module 'virtual:__federation__' has been defined in the original project)
本次提交的代码不修改原有逻辑，仅开放了外部调用，因此不必担心影响到项目。（除非原有项目里已定义了虚拟模块‘virtual:__federation__’）

插件小白，不敢动大刀，仅提供一个验证过的思路，如有更佳解决方案，欢迎告知。也欢迎批评指正。

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
