### PR TITLE
fix: Flatten module with default exports when available

### DIFF
--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -32,24 +32,23 @@ async function getSharedFromRuntime(name, shareScope) {
     }
   }
   if (module) {
-    if (module.default && Object.keys(module).length < 2)
-      module = module.default
-    moduleCache[name] = module
-    return module
+    return flattenModule(module, name)
   }
 }
 async function getSharedFromLocal(name) {
   if (moduleMap[name]?.import) {
     let module = await (await moduleMap[name].get())()
-    if (module.default && Object.keys(module).length < 2)
-      module = module.default
-    moduleCache[name] = module
-    return module
+    return flattenModule(module, name)
   } else {
     console.error(
       `consumer config import=false,so cant use callback shared module`
     )
   }
+}
+function flattenModule(module, name) {
+  if (module.default) module = Object.assign({}, module.default, module)
+  moduleCache[name] = module
+  return module
 }
 export {
   importShared,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR is relevant to the issues #498 and #499 .
The shared import is only checking if there are less than 2 properties available on the module. This check is not sufficent. For instance, React has mor than 1 export but is still relying on the default export. This breaks a React application when used as a shared library. 
This happens since the change was introduced 1.3.1

My proposel is to flatten the default export and add all module exports as well. 
This is still better than just ignore either default exports or all other exports but has of course the caveat is that some default exports get overwritten. But in the current solution there wouldn't be any exports to be overwritten anyway.



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other


