### PR TITLE
feat: add content hash to federation_fn_import file name

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -15,7 +15,7 @@
 
 import type { PluginHooks } from '../../types/pluginHooks'
 import { NAME_CHAR_REG, parseSharedOptions, removeNonRegLetter } from '../utils'
-import { builderInfo, parsedOptions } from '../public'
+import { parsedOptions } from '../public'
 import type { ConfigTypeSet, VitePluginFederationOptions } from 'types'
 import { basename, join, resolve } from 'path'
 import { readdirSync, readFileSync, statSync } from 'fs'
@@ -59,9 +59,7 @@ export function prodSharedPlugin(
       // Cannot emit chunks after module loading has finished, so emitFile first.
       if (parsedOptions.prodShared.length && isRemote) {
         this.emitFile({
-          fileName: `${
-            builderInfo.assetsDir ? builderInfo.assetsDir + '/' : ''
-          }__federation_fn_import.js`,
+          name: '__federation_fn_import',
           type: 'chunk',
           id: '__federation_fn_import',
           preserveSignature: 'strict'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After https://github.com/originjs/vite-plugin-federation/pull/487, `__federation_fn_import.js` was left without a content hash. With this pull request it will be named like `__federation_fn_import-d6086ec8.js`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
