### PR TITLE
fix: flatten module return function when module default is function

### DIFF
--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -46,6 +46,15 @@ async function getSharedFromLocal(name) {
   }
 }
 function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key]
+      }
+    })
+    return module.default
+  }
   if (module.default) module = Object.assign({}, module.default, module)
   moduleCache[name] = module
   return module

--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -53,6 +53,7 @@ function flattenModule(module, name) {
         module.default[key] = module[key]
       }
     })
+    moduleCache[name] = module.default
     return module.default
   }
   if (module.default) module = Object.assign({}, module.default, module)


### PR DESCRIPTION
### Description

remote client use shared module like dayjs which export default a function, will get a type error: xxx is not function
flattenModule function return object or not a function when module default  export is function

fix issue [537](https://github.com/originjs/vite-plugin-federation/issues/537)

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
