### PR TITLE
Add support for using the vite dev server on remotes

### DIFF
--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -13,17 +13,74 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // *****************************************************************************
 
-import { parseExposeOptions } from '../utils'
-import { parsedOptions } from '../public'
+import { resolve } from 'path'
+import { getModuleMarker, normalizePath, parseExposeOptions } from '../utils'
+import { EXTERNALS, SHARED, builderInfo, parsedOptions } from '../public'
 import type { VitePluginFederationOptions } from 'types'
 import type { PluginHooks } from '../../types/pluginHooks'
+import { ViteDevServer } from 'vite'
 
 export function devExposePlugin(
   options: VitePluginFederationOptions
 ): PluginHooks {
   parsedOptions.devExpose = parseExposeOptions(options)
+  let moduleMap = ''
+
+  // exposes module
+  for (const item of parsedOptions.devExpose) {
+    const moduleName = getModuleMarker(`\${${item[0]}}`, SHARED)
+    EXTERNALS.push(moduleName)
+    const importPath = normalizePath(item[1].import)
+    const exposeFilepath = normalizePath(resolve(item[1].import))
+    moduleMap += `\n"${item[0]}":() => {
+      return __federation_import('/${importPath}', '/@fs/${exposeFilepath}').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},`
+  }
+  const remoteFile = `
+      const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
+      let moduleMap = {
+        ${moduleMap}
+      };
+      const __federation_import = async (urlImportPath, fsImportPath) => {
+        let importedModule;
+        try {
+          return await import(urlImportPath);
+        }catch(ex) {
+          return await import(fsImportPath)
+        }
+      };
+      export const get =(module) => {
+        if(!moduleMap[module]) throw new Error('Can not find remote module ' + module)
+        return moduleMap[module]();
+      };
+      export const init =(shareScope) => {
+        globalThis.__federation_shared__= globalThis.__federation_shared__|| {};
+        Object.entries(shareScope).forEach(([key, value]) => {
+          const versionKey = Object.keys(value)[0];
+          const versionValue = Object.values(value)[0];
+          const scope = versionValue.scope || 'default'
+          globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
+          const shared= globalThis.__federation_shared__[scope];
+          (shared[key] = shared[key]||{})[versionKey] = versionValue;
+        });
+      }
+    `
 
   return {
-    name: 'originjs:expose-development'
+    name: 'originjs:expose-development',
+    configureServer: (server: ViteDevServer) => {
+      const remoteFilePath = `${builderInfo.assetsDir}/${options.filename}`
+      server.middlewares.use((req, res, next) => {
+        if (req.url && req.url.includes(remoteFilePath)) {
+          res.writeHead(200, 'OK', {
+            'Content-Type': 'text/javascript',
+            'Access-Control-Allow-Origin': '*'
+          })
+          res.write(remoteFile)
+          res.end()
+        } else {
+          next()
+        }
+      })
+    }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds support for using the vite dev server for remotes.  This addresses [issue 204](https://github.com/originjs/vite-plugin-federation/issues/204)

### Additional context

While this appears to work with the examples and the project where I'm consuming it, I'm not sure that it's very efficient.  If there are ways to be more efficient with `importShared` and its associated module cache I would appreciate the input.

I also didn't find a way to support version checking importShared without copying the `satisfy` code.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
