### PR TITLE
docs(examples): add missing step for building at repository root first

### DIFF
--- a/packages/examples/basic-host-remote/README.md
+++ b/packages/examples/basic-host-remote/README.md
@@ -3,9 +3,12 @@
 This repository is to showcase examples of how Module Federation can be used in rollup.
 
 ## Running Demo
-First, `cd packages\examples\basic-host-remote`, then run `pnpm build` and `pnpm serve`. This will build and serve both `host` and `remote` on ports 5000, 5001 respectively.
 
-- HOST (rollup-host): [localhost:5000](http://localhost:5000/)
-- REMOTE (rollup-remote): [localhost:5001](http://localhost:5001/)
+1. Clone [originjs/vite-plugin-federation](https://github.com/originjs/vite-plugin-federation) if you haven't already.
+1. At the repository root, install dependencies (`pnpm install`) and build (`pnpm build`).
+1. Go to this example folder: `cd packages\examples\basic-host-remote`
+1. Run `pnpm install`, `pnpm build` and `pnpm serve` . This will build and serve both `host` and `remote` on ports 5000, 5001 respectively:
+    - HOST (rollup-host): [localhost:5000](http://localhost:5000/)
+    - REMOTE (rollup-remote): [localhost:5001](http://localhost:5001/)
 
 `CTRL + C` can only stop the host server. You can run `pnpm stop` to stop all services.

--- a/packages/examples/vue3-demo-esm/README.md
+++ b/packages/examples/vue3-demo-esm/README.md
@@ -4,7 +4,10 @@ This example demos consumption of federated modules from a vite bundle. `layout`
 
 ## Running Demo
 
-First, `cd packages\examples\vue3-demo`, then run `pnpm build` and `pnpm serve` . This will build and serve `layout`, `home`, `common-lib` and `css-modules` on ports 5000, 5001, 5002, 5003 respectively.
+1. Clone [originjs/vite-plugin-federation](https://github.com/originjs/vite-plugin-federation) if you haven't already.
+1. At the repository root, install dependencies (`pnpm install`) and build (`pnpm build`).
+1. Go to this example folder: `cd packages\examples\vue3-demo-esm`
+1. Run `pnpm install`, `pnpm build` and `pnpm serve` . This will build and serve `layout`, `home`, `common-lib` and `css-modules` on ports 5000, 5001, 5002, 5003 respectively.
 
 - HOST (layout): [localhost:5000](http://localhost:5000/)
 - REMOTE (home): [localhost:5001](http://localhost:5001/)

--- a/packages/examples/vue3-demo-systemjs/README.md
+++ b/packages/examples/vue3-demo-systemjs/README.md
@@ -4,11 +4,13 @@ This example demos consumption of federated modules from a vite bundle. `layout`
 
 ## Running Demo
 
-First, `cd packages\examples\vue3-demo`, then run `pnpm build` and `pnpm serve` . This will build and serve `layout`, `home`, `common-lib` and `css-modules` on ports 5000, 5001, 5002, 5003 respectively.
-
-- HOST (layout): [localhost:5000](http://localhost:5000/)
-- REMOTE (home): [localhost:5001](http://localhost:5001/)
-- REMOTE (common-lib): [localhost:5002](http://localhost:5002/)
-- REMOTE (css-modules): [localhost:5003](http://localhost:5003/)
+1. Clone [originjs/vite-plugin-federation](https://github.com/originjs/vite-plugin-federation) if you haven't already.
+1. At the repository root, install dependencies (`pnpm install`) and build (`pnpm build`).
+1. Go to this example folder: `cd packages\examples\vue3-demo-systemjs`
+1. Run `pnpm install`, `pnpm build` and `pnpm serve` . This will build and serve `layout`, `home`, `common-lib` and `css-modules` on ports 5000, 5001, 5002, 5003 respectively:
+    - HOST (layout): [localhost:5000](http://localhost:5000/)
+    - REMOTE (home): [localhost:5001](http://localhost:5001/)
+    - REMOTE (common-lib): [localhost:5002](http://localhost:5002/)
+    - REMOTE (css-modules): [localhost:5003](http://localhost:5003/)
 
 `CTRL + C` can only stop the host server. You can run `pnpm stop` to stop all services.


### PR DESCRIPTION
### Description

This adds a step to some of the example README files for installing dependencies and building at the repository root first.

Fixes #513.

### Additional context

I was running into the same issue as #513 because I was following the instructions exactly, not realizing that I needed to first install dependencies and build at the repository root.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
