### PR TITLE
Fix error during build for development mode

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -45,19 +45,19 @@ export default function federation(
   let registerCount = 0
 
   function registerPlugins(mode: string, command: string) {
-    if (mode === 'development' || command === 'serve') {
-      pluginList = [
-        devSharedPlugin(options),
-        devExposePlugin(options),
-        devRemotePlugin(options)
-      ]
-    } else if (mode === 'production' || command === 'build') {
+    if (mode === 'production' || command === 'build') {
       pluginList = [
         prodSharedPlugin(options),
         prodExposePlugin(options),
         prodRemotePlugin(options)
       ]
-    } else {
+    } else if (mode === 'development' || command === 'serve') {
+      pluginList = [
+        devSharedPlugin(options),
+        devExposePlugin(options),
+        devRemotePlugin(options)
+      ]
+    }  else {
       pluginList = []
     }
     builderInfo.isHost = !!(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR solve the issue of error during build. `npx vite build --mode development`.

The `mode` can be used for environment and not limited to the command `build` or `serve`. It can be `mode=development` but command is `build`. Switching the sequence should fix the issue.

However there will be another issue, if someone want to serve a production environment. 
`npx vite serve --mode production`. For long term solution i would suggest to remove the `mode` from the condition statement.

```
error during build:
TypeError: [originjs:federation] Cannot read properties of undefined (reading 'config')
```
fixes #527 [React: Cannot read properties of undefined (reading 'config') in devSharedScopeCode](https://github.com/originjs/vite-plugin-federation/issues/527)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
