### PR TITLE
fix: removeNonRegLetter for chunk filename

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -191,7 +191,11 @@ export function prodSharedPlugin(
         if (chunk.type === 'chunk') {
           if (!isHost) {
             const regRst = sharedFilePathReg.exec(chunk.fileName)
-            if (regRst && shareName2Prop.get(regRst[1])?.generate === false) {
+            if (
+              regRst &&
+              shareName2Prop.get(removeNonRegLetter(regRst[1], NAME_CHAR_REG))
+                ?.generate === false
+            ) {
               needRemoveShared.add(key)
             }
           }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I was working on the remote side and using the shared features with a scoped package, as in the following example

```
shared: {
  '@vue/composition-api': { generate: false }
}
```

I found that the `generate: false` setting had no effect. This is because the `shareName2Prop` map applies the `removeNonRegLetter` function to the package name `@vueComposition-api` as it's key. Therefore, when determining the `needRemoveShared` condition, we should also apply `removeNonRegLetter` to the chunk filename. This change is necessary for the program to work correctly.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
