### PR TITLE
fix: The `remoteEntryChunk` should use the base path from the Vite co…

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -239,7 +239,11 @@ export function prodExposePlugin(
             const slashPath = fileRelativePath.replace(/\\/g, '/')
             remoteEntryChunk.code = remoteEntryChunk.code.replace(
               `\${__federation_expose_${expose[0]}}`,
-              `./${slashPath}`
+              [
+                viteConfigResolved.config?.base?.replace(/\/+$/, '') || '.',
+                viteConfigResolved.config?.build?.assetsDir?.replace(/\/+$/, ''),
+                slashPath
+              ].filter(Boolean).join('/')
             )
           }
         }


### PR DESCRIPTION
…nfig.

Fixes #629 

### Description

Under normal circumstances, the reference paths for resource files built by a plugin should align with the base path specified in the Vite config.

### Additional context

The `filename` of the exposed remote module usually doesn't include a hash because it's the entry point for remote modules and needs to be accessible by external applications. Therefore, it is typically deployed separately on Nginx, while other resources are placed on a CDN. If a relative path is used, it can cause a bug where files can't be found.

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
