### PR TITLE
docs: add runtime add remotes with virtual:__federation__

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ shared: {
 ## Runtime add remotes with `virtual:__federation__`
 It is not always possible to define the list of remote applications in advance in `vite.config`. Some applications may load the list of these remotes asynchronously when the user visits the website. In such cases, you can use the `virtual:__federation__` API.
 
+> Note: This is a virtual module, for a deeper understanding of virtual modules in Vite, see: https://vite.dev/guide/api-plugin#virtual-modules-convention
+
 ### API `virtual:__federation__`
 
 Using methods from the `virtual:__federation__` module, you can implement dynamic loading of a remote application.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Documentation for working with `virtual:__federation__` has been added. It addresses user questions such as "how to load a module at runtime."  
https://github.com/originjs/vite-plugin-federation/issues/642  

Describes part of the changes from https://github.com/originjs/vite-plugin-federation/pull/481.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
