### PR TITLE
Fix: preserve signature of shared librairies.

### DIFF
--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -178,7 +178,7 @@ export function prodRemotePlugin(
             sharedInfo[1].emitFile = this.emitFile({
               type: 'chunk',
               id: sharedInfo[1].id ?? sharedInfo[1].packagePath,
-              preserveSignature: 'allow-extension',
+              preserveSignature: 'strict',
               name: `__federation_shared_${sharedInfo[0]}`
             })
           }


### PR DESCRIPTION
### Description

With 'allow-extension', the build could add some additional code in files of shared librairies. But if the host embed a library, that has been extended in a remote, the remote can not access the extended code anymore.

### Additional context

I have seen this bug when I used
`import Lock from "@mui/icons-material/Lock";`
in a remote micro-frontend.
Some code to build the icon, `createSvgIcon` function, was added to the code of a shared library.

### What is the purpose of this pull request?

- [X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
