### PR TITLE
fix: update remoteEntryChunk code to handle base path correctly when …

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -78,49 +78,57 @@ export function prodExposePlugin(
       const currentImports = {}
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {${moduleMap}}
-    const seen = {}
-    export const ${DYNAMIC_LOADING_CSS} = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
-      const metaUrl = import.meta.url
-      if (typeof metaUrl == 'undefined') {
-        console.warn('The remote style takes effect only when the build.target option in the vite.config.ts file is higher than that of "es2020".')
-        return
-      }
-      const curUrl = metaUrl.substring(0, metaUrl.lastIndexOf('${options.filename}'))
-
-      cssFilePaths.forEach(cssFilePath => {
-        const href = curUrl + cssFilePath
-        if (href in seen) return
-        seen[href] = true
-        if (dontAppendStylesToHead) {
-          const key = 'css__${options.name}__' + exposeItemName;
-          if (window[key] == null) window[key] = []
-          window[key].push(href);
-        } else {
-          const element = document.head.appendChild(document.createElement('link'))
-          element.href = href
-          element.rel = 'stylesheet'
+      const seen = {}
+      export const ${DYNAMIC_LOADING_CSS} = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
+        const metaUrl = import.meta.url;
+        if (typeof metaUrl === 'undefined') {
+          console.warn('The remote style takes effect only when the build.target option in the vite.config.ts file is higher than that of "es2020".');
+          return;
         }
-      })
-    };
-    async function __federation_import(name) {
+
+        const curUrl = metaUrl.substring(0, metaUrl.lastIndexOf('${options.filename}'));
+        const base = __VITE_BASE_PLACEHOLDER__;
+        const assetsDir = __VITE_ASSETS_DIR_PLACEHOLDER__;
+
+        cssFilePaths.forEach(cssPath => {
+          const baseUrl = base || curUrl;
+          const href = [baseUrl, assetsDir, cssPath].filter(Boolean).join('/');
+
+          if (href in seen) return;
+          seen[href] = true;
+
+          if (!dontAppendStylesToHead) {
+            const element = document.createElement('link');
+            element.rel = 'stylesheet';
+            element.href = href;
+            document.head.appendChild(element);
+            return;
+          }
+
+          const key = 'css__' + options.name + '__' + exposeItemName;
+          window[key] = window[key] || [];
+          window[key].push(href);
+        });
+      };
+      async function __federation_import(name) {
         currentImports[name] ??= import(name)
         return currentImports[name]
-    };
-    export const get =(module) => {
-      if(!moduleMap[module]) throw new Error('Can not find remote module ' + module)
-      return moduleMap[module]();
-    };
-    export const init =(shareScope) => {
-      globalThis.__federation_shared__= globalThis.__federation_shared__|| {};
-      Object.entries(shareScope).forEach(([key, value]) => {
-        const versionKey = Object.keys(value)[0];
-        const versionValue = Object.values(value)[0];
-        const scope = versionValue.scope || 'default'
-        globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
-        const shared= globalThis.__federation_shared__[scope];
-        (shared[key] = shared[key]||{})[versionKey] = versionValue;
-      });
-    }`
+      };
+      export const get =(module) => {
+        if(!moduleMap[module]) throw new Error('Can not find remote module ' + module)
+        return moduleMap[module]();
+      };
+      export const init =(shareScope) => {
+        globalThis.__federation_shared__= globalThis.__federation_shared__|| {};
+        Object.entries(shareScope).forEach(([key, value]) => {
+          const versionKey = Object.keys(value)[0];
+          const versionValue = Object.values(value)[0];
+          const scope = versionValue.scope || 'default'
+          globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
+          const shared= globalThis.__federation_shared__[scope];
+          (shared[key] = shared[key]||{})[versionKey] = versionValue;
+        });
+      }`
     },
 
     configResolved(config: ResolvedConfig) {
@@ -158,6 +166,17 @@ export function prodExposePlugin(
       }
       // placeholder replace
       if (remoteEntryChunk) {
+        // 替换 base 和 assetsDir 占位符
+        remoteEntryChunk.code = remoteEntryChunk.code
+          .replace(
+            '__VITE_BASE_PLACEHOLDER__',
+            `'${viteConfigResolved.config?.base || ''}'`
+          )
+          .replace(
+            '__VITE_ASSETS_DIR_PLACEHOLDER__',
+            `'${viteConfigResolved.config?.build?.assetsDir || ''}'`
+          );
+
         const filepathMap = new Map()
         const getFilename = (name) => parse(parse(name).name).name
         const cssBundlesMap: Map<string, OutputAsset | OutputChunk> =

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -239,11 +239,18 @@ export function prodExposePlugin(
             const slashPath = fileRelativePath.replace(/\\/g, '/')
             remoteEntryChunk.code = remoteEntryChunk.code.replace(
               `\${__federation_expose_${expose[0]}}`,
-              [
-                viteConfigResolved.config?.base?.replace(/\/+$/, '') || '.',
-                viteConfigResolved.config?.build?.assetsDir?.replace(/\/+$/, ''),
-                slashPath
-              ].filter(Boolean).join('/')
+              viteConfigResolved.config?.base?.replace(/\/+$/, '')
+                ? [
+                    viteConfigResolved.config.base.replace(/\/+$/, ''),
+                    viteConfigResolved.config.build?.assetsDir?.replace(
+                      /\/+$/,
+                      ''
+                    ),
+                    slashPath
+                  ]
+                    .filter(Boolean)
+                    .join('/')
+                : `./${slashPath}`
             )
           }
         }


### PR DESCRIPTION
…Vite config is present

<!-- Thank you for contributing! -->

### Description

The issue  addressed is Duplicate assetsDir in __federation_expose_ #657. 
﻿
Before accessing `viteConfigResolved.config.base`, the code now checks if `viteConfigResolved.config.base` is configured. If it is, it concatenates it with `assetsDir`; otherwise, a fallback path (`./${slashPath}`) is used instead.
### Additional context

This concatenation error caused incorrect paths in the generated `remoteEntry` file, leading to runtime issues in production builds.
The dynamicLoadingCss function now synchronizes the base parameter provided by Vite  configuration, ensuring correct path resolution for dynamically loaded CSS files.
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.