### PR TITLE
fix: Updated the CSS file path generation logic in prodExposePlugin t…

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -91,8 +91,14 @@ export function prodExposePlugin(
         const assetsDir = __VITE_ASSETS_DIR_PLACEHOLDER__;
 
         cssFilePaths.forEach(cssPath => {
-          const baseUrl = base || curUrl;
-          const href = [baseUrl, assetsDir, cssPath].filter(Boolean).join('/');
+         let href = ''
+         const baseUrl = base || curUrl
+         console.log(baseUrl)
+         if (baseUrl && baseUrl !== '/') {
+         	href = [baseUrl, assetsDir, cssPath].filter(Boolean).join('/')
+         } else {
+         	href = curUrl + cssPath
+         }
 
           if (href in seen) return;
           seen[href] = true;

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -93,7 +93,6 @@ export function prodExposePlugin(
         cssFilePaths.forEach(cssPath => {
          let href = ''
          const baseUrl = base || curUrl
-         console.log(baseUrl)
          if (baseUrl && baseUrl !== '/') {
          	href = [baseUrl, assetsDir, cssPath].filter(Boolean).join('/')
          } else {


### PR DESCRIPTION
…o correctly handle the base URL.

<!-- Thank you for contributing! -->

### Description

This PR fixes a bug introduced in the previous PR , where the CSS file paths were not correctly handled when the Vite base configuration was not used. The current PR addresses this by ensuring proper handling of the base URL for CSS files.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
