### PR TITLE
fix: CSS path in expose-production produce double slashes

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -94,7 +94,7 @@ export function prodExposePlugin(
          let href = ''
          const baseUrl = base || curUrl
          if (baseUrl && baseUrl !== '/') {
-         	href = [baseUrl, assetsDir, cssPath].filter(Boolean).join('/')
+         	href = [baseUrl, assetsDir, cssPath].filter(Boolean).map(part => part.endsWith('/') ? part.substring(0, part.length - 1) : part).join('/')
          } else {
          	href = curUrl + cssPath
          }


### PR DESCRIPTION
 ### Description

EDIT : Sorry the problem occurs since the 1.3.8 not the 1.3.7.

Since version _1.3.8_ our federated CSS files are exposed by a wrong path (under double slashes).    
For example, the same configurations of this plugin produce :  

- **1.3.6** : 
   ```
   http://domain.com/foo/assets/__federation_expose_ModuleName-xxxx.css
   ```
- **1.3.8** :
   ```
   http://domain.com/foo//assets/__federation_expose_ModuleName-xxxx.css
   ```

### Additional context

The problem come from the usage of `join('/')` while a "base" vite can end by a slash (which is mostly the case for other plugins configurations).  

The current code looks like this :  
```typescript
const baseUrl = '/foo/';
const assetsDir = 'assets';
const cssPath = 'myFile.css';

const href = [baseUrl, assetsDir, cssPath].filter(Boolean).join('/');
// href : "/foo//assets/myFile.css"
```
With the proposed update : 
```typescript
const baseUrl = '/foo/';
const assetsDir = 'assets';
const cssPath = 'myFile.css';

const href = [baseUrl, assetsDir, cssPath].filter(Boolean).map(part => part.endsWith('/') ? part.substring(0, part.length - 1) : part).join('/');
// href : "/foo/assets/myFile.css"
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it : **I didn't find where to add a related test.**
