### PR TITLE
Fix: Ensure CSS paths include hostname for remote module styles

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@originjs/vite-plugin-federation",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "A Vite plugin which support Module Federation.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -91,12 +91,26 @@ export function prodExposePlugin(
         const assetsDir = __VITE_ASSETS_DIR_PLACEHOLDER__;
 
         cssFilePaths.forEach(cssPath => {
-         let href = ''
-         const baseUrl = base || curUrl
-         if (baseUrl && baseUrl !== '/') {
-         	href = [baseUrl, assetsDir, cssPath].filter(Boolean).map(part => part.endsWith('/') ? part.substring(0, part.length - 1) : part).join('/')
+         let href = '';
+         const baseUrl = base || curUrl;
+         if (baseUrl) {
+           const trimmer = {
+             trailing: (path) => (path.endsWith('/') ? path.slice(0, -1) : path),
+             leading: (path) => (path.startsWith('/') ? path.slice(1) : path)
+           }
+           const isAbsoluteUrl = (url) => url.startsWith('http') || url.startsWith('//');
+           
+           const cleanBaseUrl = trimmer.trailing(baseUrl);
+           const cleanCssPath = trimmer.leading(cssPath);
+           const cleanCurUrl = trimmer.trailing(curUrl);
+           
+           if (isAbsoluteUrl(baseUrl)) {
+             href = [cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+           } else {
+             href = [cleanCurUrl + cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+           }
          } else {
-         	href = curUrl + cssPath
+           href = cssPath;
          }
 
           if (href in seen) return;
@@ -180,7 +194,7 @@ export function prodExposePlugin(
           .replace(
             '__VITE_ASSETS_DIR_PLACEHOLDER__',
             `'${viteConfigResolved.config?.build?.assetsDir || ''}'`
-          );
+          )
 
         const filepathMap = new Map()
         const getFilename = (name) => parse(parse(name).name).name


### PR DESCRIPTION
### Description

This PR fixes an issue with CSS loading in remote modules where styles were being loaded from incorrect URLs missing the hostname. Previously, when loading remote module styles, the URLs were constructed without the proper hostname (e.g. `//assets/style.css` instead of `http://hostname/assets/style.css`).

The fix improves URL construction logic by:
- Properly handling both absolute and relative base URLs
- Preserving hostname when constructing style URLs
- Adding utility functions for consistent path trimming
- Ensuring proper URL joining for remote module styles

### Additional context

The issue was particularly visible when:
1. Loading remote module styles in production builds
2. Using base URLs other than root ('/')
3. Working with cross-origin remote modules

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

