### PR TITLE
fix:(css-file-paths) Check current url already has base url

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -99,15 +99,19 @@ export function prodExposePlugin(
              leading: (path) => (path.startsWith('/') ? path.slice(1) : path)
            }
            const isAbsoluteUrl = (url) => url.startsWith('http') || url.startsWith('//');
-           
+
            const cleanBaseUrl = trimmer.trailing(baseUrl);
            const cleanCssPath = trimmer.leading(cssPath);
            const cleanCurUrl = trimmer.trailing(curUrl);
-           
+
            if (isAbsoluteUrl(baseUrl)) {
              href = [cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
            } else {
-             href = [cleanCurUrl + cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+            if (cleanCurUrl.includes(cleanBaseUrl)) {
+              href = [cleanCurUrl, cleanCssPath].filter(Boolean).join('/');
+            } else {
+              href = [cleanCurUrl + cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+            }
            }
          } else {
            href = cssPath;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The url for Dynamic CSS loading was adding the baseUrl to curUrl when it already was.

![image](https://github.com/user-attachments/assets/b41a5508-81a5-4517-82e3-48dd87cc62e1)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
