### PR TITLE
Fix bug on expose-production.ts

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -128,7 +128,7 @@ export function prodExposePlugin(
             return;
           }
 
-          const key = 'css__' + options.name + '__' + exposeItemName;
+          const key = 'css__${options.name}__' + exposeItemName;
           window[key] = window[key] || [];
           window[key].push(href);
         });


### PR DESCRIPTION
Fix bug when exposing the styles to the window

<!-- Thank you for contributing! -->

### Description

Fixing bug caused on the 1.3.7 release that broke the **dontAppendStylesToHead** flag when set to true

### Additional context

When running dynamicLoadingCss throws error saying cannot read name of undefined;
To test just run Module with **dontAppendStylesToHead**, set to true in the current version(1.3.9) the error happens

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
