### PR TITLE
fix: incorrect version provided to the scope when multiple versions are available

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -144,12 +144,12 @@ export function prodExposePlugin(
       export const init =(shareScope) => {
         globalThis.__federation_shared__= globalThis.__federation_shared__|| {};
         Object.entries(shareScope).forEach(([key, value]) => {
-          const versionKey = Object.keys(value)[0];
-          const versionValue = Object.values(value)[0];
-          const scope = versionValue.scope || 'default'
-          globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
-          const shared= globalThis.__federation_shared__[scope];
-          (shared[key] = shared[key]||{})[versionKey] = versionValue;
+          for (const [versionKey, versionValue] of Object.entries(value)) {
+            const scope = versionValue.scope || 'default'
+            globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
+            const shared= globalThis.__federation_shared__[scope];
+            (shared[key] = shared[key]||{})[versionKey] = versionValue;
+          }
         });
       }`
     },

--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -19,11 +19,14 @@ async function getSharedFromRuntime(name, shareScope) {
   let module = null
   if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
     const versionObj = globalThis.__federation_shared__[shareScope][name]
-    const versionKey = Object.keys(versionObj)[0]
-    const versionValue = Object.values(versionObj)[0]
-    if (moduleMap[name]?.requiredVersion) {
-      // judge version satisfy
-      if (satisfy(versionKey, moduleMap[name].requiredVersion)) {
+    const requiredVersion = moduleMap[name]?.requiredVersion
+    const hasRequiredVersion = !!requiredVersion
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      )
+      if (versionKey) {
+        const versionValue = versionObj[versionKey]
         module = await (await versionValue.get())()
       } else {
         console.log(
@@ -31,6 +34,8 @@ async function getSharedFromRuntime(name, shareScope) {
         )
       }
     } else {
+      const versionKey = Object.keys(versionObj)[0]
+      const versionValue = versionObj[versionKey]
       module = await (await versionValue.get())()
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
> Firstly I want to thank for taking such initiative to solve this problem!
### Description
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
I tried using this package to create remoteEntry from vite and consume in webpack. But I was constantly facing a problem of double react getting loaded. On deep investigation I understood that the webpack in shareScope was providing 2 versions of react { 16: /**/, 18: /**/ } even though I provided required verison 18 in the federationPlugin it used to take 16 since the code assumes only one package will be coming.

I tried to fix it by
1. allow all versions to be part of __federation_shared__ so that whichever is required will be accessible
2. based on requiredVersion proper package will be provided to the scope
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
