### PR TITLE
fix: When packing relative paths, the resource paths are spliced incorrectly

### DIFF
--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -101,16 +101,17 @@ export function prodExposePlugin(
            const isAbsoluteUrl = (url) => url.startsWith('http') || url.startsWith('//');
 
            const cleanBaseUrl = trimmer.trailing(baseUrl);
+           const cleanAssetsDir = trimmer.leading(assetsDir);
            const cleanCssPath = trimmer.leading(cssPath);
            const cleanCurUrl = trimmer.trailing(curUrl);
 
            if (isAbsoluteUrl(baseUrl)) {
-             href = [cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+             href = [cleanBaseUrl, cleanAssetsDir, cleanCssPath].filter(Boolean).join('/');
            } else {
             if (cleanCurUrl.includes(cleanBaseUrl)) {
-              href = [cleanCurUrl, cleanCssPath].filter(Boolean).join('/');
+              href = [cleanCurUrl, cleanAssetsDir, cleanCssPath].filter(Boolean).join('/');
             } else {
-              href = [cleanCurUrl + cleanBaseUrl, cleanCssPath].filter(Boolean).join('/');
+              href = [cleanCurUrl + cleanBaseUrl, cleanAssetsDir, cleanCssPath].filter(Boolean).join('/');
             }
            }
          } else {
@@ -197,7 +198,7 @@ export function prodExposePlugin(
           )
           .replace(
             '__VITE_ASSETS_DIR_PLACEHOLDER__',
-            `'${viteConfigResolved.config?.build?.assetsDir || ''}'`
+            `'${viteConfigResolved.config?.build?.assetsDir || 'assets'}'`
           )
 
         const filepathMap = new Map()

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -100,7 +100,7 @@ export function prodExposePlugin(
            }
            const isAbsoluteUrl = (url) => url.startsWith('http') || url.startsWith('//');
 
-           const cleanBaseUrl = trimmer.trailing(baseUrl);
+           const cleanBaseUrl = trimmer.trailing(baseUrl).replace('.', '');
            const cleanAssetsDir = trimmer.leading(assetsDir);
            const cleanCssPath = trimmer.leading(cssPath);
            const cleanCurUrl = trimmer.trailing(curUrl);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix: https://github.com/originjs/vite-plugin-federation/issues/706
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
