### PR TITLE
feat: cjs interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ function __federation_method_setRemote(name: string, config: IRemoteConfig): voi
 interface IRemoteConfig {
     url: (() => Promise<string>) | string; 
     format: "esm" | "systemjs" | "var";   
-    from: "vite" | "webpack;
+    from: "vite" | "webpack";
 }
 ```
 

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -76,7 +76,7 @@ const loadJS = async (url, fn) => {
 }
 function get(name, ${REMOTE_FROM_PARAMETER}){
   return import(/* @vite-ignore */ name).then(module => ()=> {
-    if (${REMOTE_FROM_PARAMETER} === 'webpack') {
+    if ((globalThis.__federation_shared_remote_from__ ?? ${REMOTE_FROM_PARAMETER}) === 'webpack') {
       return Object.prototype.toString.call(module).indexOf('Module') > -1 && module.default ? module.default : module
     }
     return module

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -141,7 +141,7 @@ function __federation_method_wrapDefault(module ,need){
   return module; 
 }
 
-function __federation_method_getRemote(remoteName,  componentName){
+function __federation_method_getRemote(remoteName, componentName) {
   return __federation_method_ensure(remoteName).then((remote) => remote.get(componentName).then(factory => factory()));
 }
 
@@ -395,7 +395,9 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
         const idx = moduleFilePath.indexOf(cwdPath)
 
         const relativePath =
-          idx === 0 ? posix.join(base, moduleFilePath.slice(cwdPath.length)) : null
+          idx === 0
+            ? posix.join(base, moduleFilePath.slice(cwdPath.length))
+            : null
 
         const sharedName = item[0]
         const obj = item[1]
@@ -406,7 +408,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
           const url = origin
             ? `'${origin}${pathname}'`
             : `window.location.origin+'${pathname}'`
-          str += `get:()=> get(${url}, ${REMOTE_FROM_PARAMETER})`
+          str += `get:() => get(${url}, ${REMOTE_FROM_PARAMETER})`
           res.push(`'${sharedName}':{'${obj.version}':{${str}}}`)
         }
       }

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -214,10 +214,7 @@ export function prodRemotePlugin(
                 }
 
                 function __federation_method_getRemote(remoteName, componentName) {
-                    return __federation_method_ensure(remoteName).then(async (remote) => {
-                      const factory = await remote.get(componentName);
-                      return factory();
-                    });
+                    return __federation_method_ensure(remoteName).then((remote) => remote.get(componentName).then(factory => factory()));
                 }
 
                 function __federation_method_setRemote(remoteName, remoteConfig) {

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -299,13 +299,7 @@ export function prodRemotePlugin(
               res.push(`'${arr[0]}':{'${obj.version}':{${str}}}`)
             }
           })
-          const moduleMarker = getModuleMarker('shareScope')
-          console.log('Module marker', moduleMarker)
-          const replacement = res.join(', ')
-          console.log('Replacement:', replacement)
-          const replacedCode = code.replace(moduleMarker, replacement)
-          console.debug('Replaced code', replacedCode)
-          return replacedCode
+          return code.replace(getModuleMarker('shareScope'), res.join(','))
         }
       }
 

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -290,20 +290,12 @@ export function prodRemotePlugin(
       if (builderInfo.isHost) {
         if (id === '\0virtual:__federation__') {
           const res: string[] = []
-          console.log('parsed options prod shared', parsedOptions.prodShared)
           parsedOptions.prodShared.forEach((arr) => {
             const obj = arr[1]
             let str = ''
             if (typeof obj === 'object') {
-              console.log('Replacing host code', arr)
               const fileUrl = `import.meta.ROLLUP_FILE_URL_${obj.emitFile}`
               str += `get:() => get(${fileUrl}, ${REMOTE_FROM_PARAMETER}), loaded:1`
-              // If interop === 'cjs', unwrap ESM namespace to default before seeding the share scope.
-              // Otherwise (default 'esm'), keep the module as-is.
-              // const needsCJS = obj.interop === 'cjs'
-              // str += `get:()=>get(${fileUrl}, ${REMOTE_FROM_PARAMETER})${
-              //   needsCJS ? '.then(m=>__federation_method_unwrapDefault(m))' : ''
-              // }, loaded:1`
               res.push(`'${arr[0]}':{'${obj.version}':{${str}}}`)
             }
           })

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -251,6 +251,5 @@ export function getFileExtname(url: string): string {
   return path.extname(fileName)
 }
 
-export const REMOTE_FORMAT_PARAMETER = 'remoteFormat'
 export const REMOTE_FROM_PARAMETER = 'remoteFrom'
 export const NAME_CHAR_REG = new RegExp('[0-9a-zA-Z@_-]+')

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -251,5 +251,6 @@ export function getFileExtname(url: string): string {
   return path.extname(fileName)
 }
 
+export const REMOTE_FORMAT_PARAMETER = 'remoteFormat'
 export const REMOTE_FROM_PARAMETER = 'remoteFrom'
 export const NAME_CHAR_REG = new RegExp('[0-9a-zA-Z@_-]+')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hi. Love your package. In my team, we have a small issue where we are running a nested microfrontend setup with the inner most MFE being Webpack (var) and the other two being Vite (esm). When running the middle MFE with the nested MFE things are all fine, since the shared scope initialises as expected (var). However, when running all three together, the shared scope initialises as Vite (ESM) since that is what the middle MFE is running as. When the inner-most MFE goes to import modules, the `merge` function call in [/packages/lib/src/dev/remote-production.ts - Line 150](https://github.com/originjs/vite-plugin-federation/blob/main/packages/lib/src/prod/remote-production.ts#L150) makes the assumption that the remote format/from is the same as what is already loaded into `globalThis`. However, in such as situation as I describe above, this is not the case!

I acknowledge on the README there is the following point
> 2. It is not recommended to mix `Vite` and `Webpack` in `React` projects, as there is no guarantee that `Vite/Rollup` and `Webpack` will generate the same `chunk` when packaging `commonjs`, which may cause problems with `shared`.

... however, my PR aims to fix this issue by ensuring shared modules are seeded correctly even in cases of cross-runtime federation interoperability!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
My solution involves setting a global variable to the "remote from" of the share scope which is being loaded. Then in the `get` callback, we use this as a priority over the already-bound `${REMOTE_FROM_PARAMETER}` parameter (set when the outer-most app or host begins its share scope initialisation).

I tried to curry the remote from into the `get` callback but since we rely on Webpack to actually call the `get` function, I don't think this is possible without reinitialising the share scope (around where `getModuleMarker` is called). This could be a viable solution but might slightly hurt performance. Thoughts welcome.

Hugo

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
