### PR TITLE
Null-safe share-scope merge

### DIFF
--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -139,7 +139,7 @@ export function prodRemotePlugin(
                 function merge(obj1, obj2) {
                   const mergedObj = Object.assign(obj1, obj2);
                   for (const key of Object.keys(mergedObj)) {
-                    if (typeof mergedObj[key] === 'object' && typeof obj2[key] === 'object') {
+                    if (mergedObj[key] !== null && typeof mergedObj[key] === 'object' && typeof obj2[key] === 'object') {
                       mergedObj[key] = merge(mergedObj[key], obj2[key]);
                     }
                   }


### PR DESCRIPTION
### Description

Fixes a bug occurring when loading a **VitePluginFederation** remote in an application that mixes **ModuleFederation** and **VitePluginFederation** remotes.  

When a remote **ModuleFederation** is already present in the share scope, a `loading: null` property is set ([source](https://github.com/module-federation/core/blob/main/packages/runtime-core/src/utils/share.ts#L41)).  
During share scope merging, since `typeof null === "object"`, the call to `Object.assign(null, …)` throws the following error: `Cannot convert undefined or null to object`.

This fix adds a null check to prevent calling `Object.assign` on a `null` value.

(maybe it is recommended to have a dedicated scope for this kind of case?)

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
