### PR TITLE
Add logging for module resolution from host

### DIFF
--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -30,8 +30,9 @@ async function getSharedFromRuntime(name, shareScope) {
         module = await (await versionValue.get())()
       } else {
         console.log(
-          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+          `provider support ${name} is not satisfied requiredVersion(${moduleMap[name].requiredVersion}). Debug logging will show available modules and versions.`
         )
+        console.debug(moduleMap);
       }
     } else {
       const versionKey = Object.keys(versionObj)[0]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed that will trying to resolve mixed versions of modules from a remote and a host that the log output did not actually
log the versions. I added an additional debug statement so that developers could inspect the resolved module map to determine what versions of modules were available in the host. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Code of Conduct](https://github.com/originjs/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/originjs/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
