### PR TITLE
fix: resolve E2E test failures on Node 22+ (import attributes, port conflicts, server readiness)

### DIFF
--- a/packages/examples/basic-host-remote/README.md
+++ b/packages/examples/basic-host-remote/README.md
@@ -7,8 +7,8 @@ This repository is to showcase examples of how Module Federation can be used in 
 1. Clone [originjs/vite-plugin-federation](https://github.com/originjs/vite-plugin-federation) if you haven't already.
 1. At the repository root, install dependencies (`pnpm install`) and build (`pnpm build`).
 1. Go to this example folder: `cd packages\examples\basic-host-remote`
-1. Run `pnpm install`, `pnpm build` and `pnpm serve` . This will build and serve both `host` and `remote` on ports 5000, 5001 respectively:
-    - HOST (rollup-host): [localhost:5000](http://localhost:5000/)
-    - REMOTE (rollup-remote): [localhost:5001](http://localhost:5001/)
+1. Run `pnpm install`, `pnpm build` and `pnpm serve` . This will build and serve both `host` and `remote` on ports 5030, 5031 respectively:
+    - HOST (rollup-host): [localhost:5030](http://localhost:5030/)
+    - REMOTE (rollup-remote): [localhost:5031](http://localhost:5031/)
 
 `CTRL + C` can only stop the host server. You can run `pnpm stop` to stop all services.

--- a/packages/examples/basic-host-remote/package.json
+++ b/packages/examples/basic-host-remote/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm --parallel --filter \"./**\" build",
     "serve": "pnpm --parallel --filter \"./**\" serve",
-    "stop": "kill-port --port 5000,5001"
+    "stop": "kill-port --port 5030,5031"
   },
   "license": "MulanPSL-2.0",
   "devDependencies": {

--- a/packages/examples/basic-host-remote/rollup-host/package.json
+++ b/packages/examples/basic-host-remote/rollup-host/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "rollup -c",
-    "serve": "http-server . -p 5000 --cors='*'"
+    "serve": "http-server . -p 5030 --cors='*'"
   },
   "devDependencies": {
     "rollup": "^3.9.1"

--- a/packages/examples/basic-host-remote/rollup-host/rollup.config.mjs
+++ b/packages/examples/basic-host-remote/rollup-host/rollup.config.mjs
@@ -1,6 +1,6 @@
 import federation from "@originjs/vite-plugin-federation";
 
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 export default {
   input: "src/index.js",

--- a/packages/examples/basic-host-remote/rollup-host/rollup.config.mjs
+++ b/packages/examples/basic-host-remote/rollup-host/rollup.config.mjs
@@ -8,7 +8,7 @@ export default {
   plugins: [
     federation({
       remotes: {
-        remote_app: "http://localhost:5001/remoteEntry.js",
+        remote_app: "http://localhost:5031/remoteEntry.js",
       }
     }),
   ],

--- a/packages/examples/basic-host-remote/rollup-remote/package.json
+++ b/packages/examples/basic-host-remote/rollup-remote/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "rollup -c",
-    "serve": "http-server ./dist -p 5001 --cors='*'"
+    "serve": "http-server ./dist -p 5031 --cors='*'"
   },
   "devDependencies": {
     "rollup": "^3.9.1"

--- a/packages/examples/simple-react-esm/host-esm/rollup.config.mjs
+++ b/packages/examples/simple-react-esm/host-esm/rollup.config.mjs
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import federation from '@originjs/vite-plugin-federation'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 import replace from '@rollup/plugin-replace'
 
 export default {

--- a/packages/examples/simple-react-esm/remote-esm/rollup.config.mjs
+++ b/packages/examples/simple-react-esm/remote-esm/rollup.config.mjs
@@ -3,7 +3,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import federation from '@originjs/vite-plugin-federation'
 import replace from '@rollup/plugin-replace'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 
 export default {
   input: 'src/index.js',

--- a/packages/examples/simple-react-systemjs/README.md
+++ b/packages/examples/simple-react-systemjs/README.md
@@ -4,9 +4,9 @@ This example demos consumption of federated modules from a rollup bundle. `remot
 
 ## Running Demo
 
-First, `cd packages/examples/simple-react`, then run `pnpm build` and `pnpm serve`. This will build and serve both `host` and `remote` on ports 5000, 5001 respectively.
+First, `cd packages/examples/simple-react`, then run `pnpm build` and `pnpm serve`. This will build and serve both `host` and `remote` on ports 5020, 5021 respectively.
 
-- HOST (host): [localhost:5000](http://localhost:5000/)
-- REMOTE (remote): [localhost:5001](http://localhost:5001/)
+- HOST (host): [localhost:5020](http://localhost:5020/)
+- REMOTE (remote): [localhost:5021](http://localhost:5021/)
 
 `CTRL + C` can only stop the host server. You can run `pnpm stop` to stop all services.

--- a/packages/examples/simple-react-systemjs/host-systemjs/package.json
+++ b/packages/examples/simple-react-systemjs/host-systemjs/package.json
@@ -5,7 +5,7 @@
   "license": "MulanPSL-2.0",
   "scripts": {
     "build": "rollup -c",
-    "serve": "http-server . -p 5000 --cors='*'"
+    "serve": "http-server . -p 5020 --cors='*'"
   },
   "dependencies": {
     "cross-env": "^7.0.3",

--- a/packages/examples/simple-react-systemjs/host-systemjs/rollup.config.mjs
+++ b/packages/examples/simple-react-systemjs/host-systemjs/rollup.config.mjs
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import federation from '@originjs/vite-plugin-federation'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 import replace from '@rollup/plugin-replace'
 
 export default {

--- a/packages/examples/simple-react-systemjs/host-systemjs/rollup.config.mjs
+++ b/packages/examples/simple-react-systemjs/host-systemjs/rollup.config.mjs
@@ -20,7 +20,7 @@ export default {
     federation({
       remotes: {
         remote_app: {
-          external: 'http://localhost:5001/remoteEntry.js',
+          external: 'http://localhost:5021/remoteEntry.js',
           from: 'vite',
           format: 'esm'
         }

--- a/packages/examples/simple-react-systemjs/package.json
+++ b/packages/examples/simple-react-systemjs/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "pnpm --parallel --filter \"./**\" build ",
     "serve": "pnpm --parallel --filter \"./**\" serve",
-    "stop": "kill-port --port 5000,5001"
+    "stop": "kill-port --port 5020,5021"
   },
   "devDependencies": {
     "@originjs/vite-plugin-federation": "workspace:*",

--- a/packages/examples/simple-react-systemjs/remote-systemjs/package.json
+++ b/packages/examples/simple-react-systemjs/remote-systemjs/package.json
@@ -5,7 +5,7 @@
   "license": "MulanPSL-2.0",
   "scripts": {
     "build": "rollup -c",
-    "serve": "http-server ./dist -p 5001 --cors='*'"
+    "serve": "http-server ./dist -p 5021 --cors='*'"
   },
   "dependencies": {
     "cross-env": "^7.0.3",

--- a/packages/examples/simple-react-systemjs/remote-systemjs/rollup.config.mjs
+++ b/packages/examples/simple-react-systemjs/remote-systemjs/rollup.config.mjs
@@ -3,7 +3,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import federation from '@originjs/vite-plugin-federation'
 import replace from '@rollup/plugin-replace'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 
 export default {
   input: 'src/index.js',

--- a/packages/examples/simple-react-webpack/host/index.js
+++ b/packages/examples/simple-react-webpack/host/index.js
@@ -10,7 +10,7 @@ System.register(['./__federation_shared_react.js', './__federation_shared_react-
     execute: (function() {
 
       const remotesMap = {
-        'remote_app': () => __federation_import('http://localhost:5001/remoteEntry.js')
+        'remote_app': () => __federation_import('http://localhost:5041/remoteEntry.js')
       }
       const processModule = (mod) => {
         if (mod && mod.default) {

--- a/packages/examples/simple-react-webpack/host/package.json
+++ b/packages/examples/simple-react-webpack/host/package.json
@@ -5,7 +5,7 @@
   "license": "MulanPSL-2.0",
   "scripts": {
     "build": "rollup -c",
-    "serve": "http-server . -p 5000 --cors='*'"
+    "serve": "http-server . -p 5040 --cors='*'"
   },
   "dependencies": {
     "cross-env": "^7.0.3",

--- a/packages/examples/simple-react-webpack/host/rollup.config.mjs
+++ b/packages/examples/simple-react-webpack/host/rollup.config.mjs
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import federation from '@originjs/vite-plugin-federation'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 import replace from '@rollup/plugin-replace'
 
 export default {

--- a/packages/examples/simple-react-webpack/host/rollup.config.mjs
+++ b/packages/examples/simple-react-webpack/host/rollup.config.mjs
@@ -21,7 +21,7 @@ export default {
     federation({
       remotes: {
         remote_app: {
-          external: 'http://localhost:5001/remoteEntry.js',
+          external: 'http://localhost:5041/remoteEntry.js',
           from: 'webpack'
         }
       },

--- a/packages/examples/simple-react-webpack/package.json
+++ b/packages/examples/simple-react-webpack/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "pnpm --parallel --filter \"./**\" build",
     "serve": "pnpm --parallel --filter \"./**\" serve",
-    "stop": "kill-port --port 5000,5001"
+    "stop": "kill-port --port 5040,5041"
   },
   "devDependencies": {
     "@originjs/vite-plugin-federation": "workspace:*",

--- a/packages/examples/simple-react-webpack/remote/package.json
+++ b/packages/examples/simple-react-webpack/remote/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack-cli serve",
     "build": "webpack --mode development",
-    "serve": "serve dist -p 5001 --cors='*'",
+    "serve": "serve dist -p 5041 --cors='*'",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/examples/simple-react-webpack/remote/package.json
+++ b/packages/examples/simple-react-webpack/remote/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "serve": "^14.0.0",
+    "html-webpack-plugin": "^5.5.0",
     "@babel/core": "^7.20.7",
     "@babel/preset-react": "^7.18.6",
     "babel-loader": "^9.1.0",

--- a/packages/examples/simple-react-webpack/remote/webpack.config.js
+++ b/packages/examples/simple-react-webpack/remote/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   output: {
     libraryTarget: 'system',
     libraryExport: 'main',
-    publicPath: 'http://localhost:5001/'
+    publicPath: 'http://localhost:5041/'
   },
   optimization: {
     // minimize: true,
@@ -59,7 +59,7 @@ module.exports = {
     static: {
       directory: path.join(__dirname)
     },
-    port: 5001,
+    port: 5041,
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',

--- a/packages/examples/vitestSetup-dev.ts
+++ b/packages/examples/vitestSetup-dev.ts
@@ -98,6 +98,9 @@ beforeAll(async (s) => {
 
       const portMap: Record<string, number> = {
         'webpack-host': 5010,
+        'simple-react-systemjs': 5020,
+        'basic-host-remote': 5030,
+        'simple-react-webpack': 5040,
       }
       const port = portMap[testName] ?? 5000
       // use resolved port/base from server

--- a/packages/examples/vitestSetup-dev.ts
+++ b/packages/examples/vitestSetup-dev.ts
@@ -26,6 +26,18 @@ export let viteTestUrl: string = ''
 
 const DIR = join(os.tmpdir(), 'vitest_playwright_global_setup')
 
+const waitForServer = async (url: string, timeout = 30000) => {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+    } catch {}
+    await new Promise(r => setTimeout(r, 500))
+  }
+  throw new Error(`Server at ${url} not ready after ${timeout}ms`)
+}
+
 let err: Error
 let skipError: boolean
 
@@ -84,9 +96,13 @@ beforeAll(async (s) => {
       await execa('pnpm', ['run', 'build:remotes'], {cwd: testDir, stdio: 'inherit'})
 
 
-      const port = 5000
+      const portMap: Record<string, number> = {
+        'webpack-host': 5010,
+      }
+      const port = portMap[testName] ?? 5000
       // use resolved port/base from server
       viteTestUrl = `http://localhost:${port}`
+      await waitForServer(viteTestUrl)
       await page.goto(viteTestUrl)
     }
   } catch (e) {
@@ -101,7 +117,7 @@ beforeAll(async (s) => {
     // a timeout with an exception that hides the real error in the console.
     await page.close()
   }
-}, 60000)
+}, 120000)
 
 afterAll(async () => {
   await page?.close()

--- a/packages/examples/vitestSetup-serve.ts
+++ b/packages/examples/vitestSetup-serve.ts
@@ -26,6 +26,18 @@ export let viteTestUrl = ''
 
 const DIR = join(os.tmpdir(), 'vitest_playwright_global_setup')
 
+const waitForServer = async (url: string, timeout = 30000) => {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+    } catch {}
+    await new Promise(r => setTimeout(r, 500))
+  }
+  throw new Error(`Server at ${url} not ready after ${timeout}ms`)
+}
+
 let err: Error
 let skipError: boolean
 
@@ -81,9 +93,13 @@ beforeAll(async (s) => {
       execa('pnpm', ['run', 'serve'], { cwd: testDir, stdio: 'inherit' })
       await execa('pnpm', ['run', 'build'], { cwd: testDir, stdio: 'inherit' })
 
-      const port = 5000
+      const portMap: Record<string, number> = {
+        'webpack-host': 5010,
+      }
+      const port = portMap[testName] ?? 5000
       // use resolved port/base from server
       viteTestUrl = `http://localhost:${port}`
+      await waitForServer(viteTestUrl)
       await page.goto(viteTestUrl)
     }
   } catch (e) {
@@ -98,7 +114,7 @@ beforeAll(async (s) => {
     // a timeout with an exception that hides the real error in the console.
     await page.close()
   }
-}, 60000)
+}, 120000)
 
 afterAll(async () => {
   await page?.close()

--- a/packages/examples/vitestSetup-serve.ts
+++ b/packages/examples/vitestSetup-serve.ts
@@ -95,6 +95,9 @@ beforeAll(async (s) => {
 
       const portMap: Record<string, number> = {
         'webpack-host': 5010,
+        'simple-react-systemjs': 5020,
+        'basic-host-remote': 5030,
+        'simple-react-webpack': 5040,
       }
       const port = portMap[testName] ?? 5000
       // use resolved port/base from server

--- a/packages/examples/webpack-host/README.md
+++ b/packages/examples/webpack-host/README.md
@@ -4,9 +4,9 @@ This example demos consumption of federated modules from a vite bundle as a remo
 
 ## Running
 
-First, run `pnpm install`, then `pnpm run build` and `pnpm run serve`. This will build and serve both `host` and `remote` on ports 5000, 5001 respectively.
+First, run `pnpm install`, then `pnpm run build` and `pnpm run serve`. This will build and serve both `host` and `remote` on ports 5010, 5011 respectively.
 
 - HOST: [localhost:8080](http://localhost:8080/)
-- REMOTE: [localhost:5001](http://localhost:5001/)
+- REMOTE: [localhost:5011](http://localhost:5011/)
 
 `CTRL + C` can only stop the host server. You can run `pnpm stop` to stop all services.

--- a/packages/examples/webpack-host/host/package.json
+++ b/packages/examples/webpack-host/host/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack-cli serve",
     "build": "webpack --mode development",
-    "serve": "serve dist -p 5000 --cors='*'",
+    "serve": "serve dist -p 5010 --cors='*'",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/examples/webpack-host/host/webpack.config.js
+++ b/packages/examples/webpack-host/host/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
       name: 'webpackHost',
       filename: 'remoteEntry.js',
       remotes: {
-        viteRemote: `promise import("http://localhost:5001/assets/remoteEntry.js")`,
+        viteRemote: `promise import("http://localhost:5011/assets/remoteEntry.js")`,
       },
       shared: {
         react: {

--- a/packages/examples/webpack-host/package.json
+++ b/packages/examples/webpack-host/package.json
@@ -7,7 +7,7 @@
     "build:remotes": "pnpm --filter \"./remote\"  build",
     "serve:remotes": "pnpm --filter \"./remote\"  serve",
     "dev:hosts": "pnpm --filter \"./host\" dev",
-    "stop": "kill-port --port 5000,5001"
+    "stop": "kill-port --port 5010,5011"
   },
   "workspaces": [
     "host",

--- a/packages/examples/webpack-host/remote/package.json
+++ b/packages/examples/webpack-host/remote/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 5001 --strictPort",
+    "dev": "vite --port 5011 --strictPort",
     "build": "vite build",
-    "preview": "vite preview --port 5001 --strictPort",
-    "serve": "vite preview --port 5001 --strictPort"
+    "preview": "vite preview --port 5011 --strictPort",
+    "serve": "vite preview --port 5011 --strictPort"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,7 +430,10 @@ importers:
         version: 7.18.6(@babel/core@7.20.7)
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0)
+      html-webpack-plugin:
+        specifier: ^5.5.0
+        version: 5.5.0(webpack@5.76.0)
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
@@ -875,7 +878,7 @@ importers:
         version: 7.20.7
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0)
       serve:
         specifier: ^14.0.0
         version: 14.0.1
@@ -885,22 +888,22 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^6.7.1
-        version: 6.7.1(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.7.1(webpack@5.76.0)
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.2.0(webpack@5.76.0)
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 5.3.2(webpack@5.76.0)
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.6.1(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 2.6.1(webpack@5.76.0)
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.76.0(webpack-cli@5.0.1)))(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.76.0))(webpack@5.76.0)
       vue-loader:
         specifier: ^17.0.0
-        version: 17.0.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 17.0.0(webpack@5.76.0)
       webpack:
         specifier: ^5.76.0
         version: 5.76.0(webpack-cli@5.0.1)
@@ -943,7 +946,7 @@ importers:
         version: 7.20.7
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0)
       serve:
         specifier: ^14.0.0
         version: 14.0.1
@@ -953,22 +956,22 @@ importers:
     devDependencies:
       css-loader:
         specifier: 6.3.0
-        version: 6.3.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.3.0(webpack@5.76.0)
       file-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.2.0(webpack@5.76.0)
       html-webpack-plugin:
         specifier: 5.3.2
-        version: 5.3.2(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 5.3.2(webpack@5.76.0)
       mini-css-extract-plugin:
         specifier: 2.6.1
-        version: 2.6.1(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 2.6.1(webpack@5.76.0)
       url-loader:
         specifier: 4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.76.0(webpack-cli@5.0.1)))(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.76.0))(webpack@5.76.0)
       vue-loader:
         specifier: 17.0.0
-        version: 17.0.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 17.0.0(webpack@5.76.0)
       webpack:
         specifier: ^5.76.0
         version: 5.76.0(webpack-cli@5.0.1)
@@ -1014,7 +1017,7 @@ importers:
         version: 7.20.7
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0)
       serve:
         specifier: ^14.0.0
         version: 14.0.1
@@ -1024,22 +1027,22 @@ importers:
     devDependencies:
       css-loader:
         specifier: 6.3.0
-        version: 6.3.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.3.0(webpack@5.76.0)
       file-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.2.0(webpack@5.76.0)
       html-webpack-plugin:
         specifier: 5.3.2
-        version: 5.3.2(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 5.3.2(webpack@5.76.0)
       mini-css-extract-plugin:
         specifier: 2.6.1
-        version: 2.6.1(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 2.6.1(webpack@5.76.0)
       url-loader:
         specifier: 4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.76.0(webpack-cli@5.0.1)))(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.76.0))(webpack@5.76.0)
       vue-loader:
         specifier: 17.0.0
-        version: 17.0.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 17.0.0(webpack@5.76.0)
       webpack:
         specifier: ^5.76.0
         version: 5.76.0(webpack-cli@5.0.1)
@@ -1095,13 +1098,13 @@ importers:
         version: 7.18.6(@babel/core@7.20.7)
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 9.1.0(@babel/core@7.20.7)(webpack@5.76.0)
       css-loader:
         specifier: ^6.7.3
-        version: 6.7.3(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 6.7.3(webpack@5.76.0)
       html-webpack-plugin:
         specifier: ^5.5.0
-        version: 5.5.0(webpack@5.76.0(webpack-cli@5.0.1))
+        version: 5.5.0(webpack@5.76.0)
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
@@ -2233,24 +2236,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.2.224':
     resolution: {integrity: sha512-jnrYqXc7aRzBnEqEp3nAi9tjuUhBnN0pSKiHJytlBP1QkXnH7HD44Da9udmKUFYB5hHpwaXE0NIh7jK0nSMnhw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.2.224':
     resolution: {integrity: sha512-UBkeDlG+PrIXDH1sR4EIXN5qK4a677IHb6RBghbvBDJS61X9/nTDxtCF7/zCqDxJRahhUrT6lDsYpuLCws2hiw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.2.224':
     resolution: {integrity: sha512-CQMGDzxKvkzf6TOdaWnmhb6uk1XEhM/mM3BDfX+hx9j3Hg3bFw9qmPvrkoWI2G8J50MvpoR1iPBYyG2LNeQWeg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.2.224':
     resolution: {integrity: sha512-03V4apubsOhLKQNmfWGlgvDCJkhlh0ZOHcGddxb7bD4PeP6U0lnABG3hlz2uicwcIGBPu/p7jtm5/hezeiXE6Q==}
@@ -7215,34 +7222,24 @@ snapshots:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))':
+  '@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)':
     dependencies:
       webpack: 5.76.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0)
 
-  '@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))':
-    dependencies:
-      webpack: 5.76.0(webpack-cli@5.0.1)
-      webpack-cli: 5.0.1(webpack@5.76.0)
-
-  '@webpack-cli/info@2.0.1(webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))':
+  '@webpack-cli/info@2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)':
     dependencies:
       webpack: 5.76.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0)
 
-  '@webpack-cli/info@2.0.1(webpack-cli@5.0.1(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))':
-    dependencies:
-      webpack: 5.76.0(webpack-cli@5.0.1)
-      webpack-cli: 5.0.1(webpack@5.76.0)
-
-  '@webpack-cli/serve@2.0.1(webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0))(webpack-dev-server@4.11.1(webpack-cli@5.0.1)(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))':
+  '@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack-dev-server@4.11.1)(webpack@5.76.0)':
     dependencies:
       webpack: 5.76.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0)
     optionalDependencies:
       webpack-dev-server: 4.11.1(webpack-cli@5.0.1)(webpack@5.76.0)
 
-  '@webpack-cli/serve@2.0.1(webpack-cli@5.0.1(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))':
+  '@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)':
     dependencies:
       webpack: 5.76.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.76.0)
@@ -7374,7 +7371,7 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
-  babel-loader@9.1.0(@babel/core@7.20.7)(webpack@5.76.0(webpack-cli@5.0.1)):
+  babel-loader@9.1.0(@babel/core@7.20.7)(webpack@5.76.0):
     dependencies:
       '@babel/core': 7.20.7
       find-cache-dir: 3.3.2
@@ -7783,7 +7780,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.3.0(webpack@5.76.0(webpack-cli@5.0.1)):
+  css-loader@6.3.0(webpack@5.76.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -7795,7 +7792,7 @@ snapshots:
       semver: 7.3.8
       webpack: 5.76.0(webpack-cli@5.0.1)
 
-  css-loader@6.7.1(webpack@5.76.0(webpack-cli@5.0.1)):
+  css-loader@6.7.1(webpack@5.76.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -7807,7 +7804,7 @@ snapshots:
       semver: 7.3.8
       webpack: 5.76.0(webpack-cli@5.0.1)
 
-  css-loader@6.7.3(webpack@5.76.0(webpack-cli@5.0.1)):
+  css-loader@6.7.3(webpack@5.76.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -8274,7 +8271,7 @@ snapshots:
     dependencies:
       flat-cache: 3.0.4
 
-  file-loader@6.2.0(webpack@5.76.0(webpack-cli@5.0.1)):
+  file-loader@6.2.0(webpack@5.76.0):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
@@ -8513,7 +8510,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.14.1
 
-  html-webpack-plugin@5.3.2(webpack@5.76.0(webpack-cli@5.0.1)):
+  html-webpack-plugin@5.3.2(webpack@5.76.0):
     dependencies:
       '@types/html-minifier-terser': 5.1.2
       html-minifier-terser: 5.1.1
@@ -8522,7 +8519,7 @@ snapshots:
       tapable: 2.2.1
       webpack: 5.76.0(webpack-cli@5.0.1)
 
-  html-webpack-plugin@5.5.0(webpack@5.76.0(webpack-cli@5.0.1)):
+  html-webpack-plugin@5.5.0(webpack@5.76.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -8984,7 +8981,7 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mini-css-extract-plugin@2.6.1(webpack@5.76.0(webpack-cli@5.0.1)):
+  mini-css-extract-plugin@2.6.1(webpack@5.76.0):
     dependencies:
       schema-utils: 4.0.0
       webpack: 5.76.0(webpack-cli@5.0.1)
@@ -9923,7 +9920,7 @@ snapshots:
       esbuild: 0.17.19
     optional: true
 
-  terser-webpack-plugin@5.3.3(webpack@5.76.0(webpack-cli@5.0.1)):
+  terser-webpack-plugin@5.3.3(webpack@5.76.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.14
       jest-worker: 27.5.1
@@ -10083,14 +10080,14 @@ snapshots:
 
   url-join@2.0.5: {}
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.76.0(webpack-cli@5.0.1)))(webpack@5.76.0(webpack-cli@5.0.1)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.76.0))(webpack@5.76.0):
     dependencies:
       loader-utils: 2.0.2
       mime-types: 2.1.35
       schema-utils: 3.1.1
       webpack: 5.76.0(webpack-cli@5.0.1)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.76.0(webpack-cli@5.0.1))
+      file-loader: 6.2.0(webpack@5.76.0)
 
   util-deprecate@1.0.2: {}
 
@@ -10191,7 +10188,7 @@ snapshots:
     dependencies:
       vue: 3.2.45
 
-  vue-loader@17.0.0(webpack@5.76.0(webpack-cli@5.0.1)):
+  vue-loader@17.0.0(webpack@5.76.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
@@ -10234,9 +10231,9 @@ snapshots:
   webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))
-      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))
-      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0))(webpack-dev-server@4.11.1(webpack-cli@5.0.1)(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))
+      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)
+      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)
+      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1)(webpack-dev-server@4.11.1)(webpack@5.76.0)
       colorette: 2.0.19
       commander: 9.4.1
       cross-spawn: 7.0.3
@@ -10253,9 +10250,9 @@ snapshots:
   webpack-cli@5.0.1(webpack@5.76.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))
-      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))
-      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1(webpack@5.76.0))(webpack@5.76.0(webpack-cli@5.0.1))
+      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)
+      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)
+      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1)(webpack@5.76.0)
       colorette: 2.0.19
       commander: 9.4.1
       cross-spawn: 7.0.3
@@ -10267,7 +10264,7 @@ snapshots:
       webpack: 5.76.0(webpack-cli@5.0.1)
       webpack-merge: 5.8.0
 
-  webpack-dev-middleware@5.3.3(webpack@5.76.0(webpack-cli@5.0.1)):
+  webpack-dev-middleware@5.3.3(webpack@5.76.0):
     dependencies:
       colorette: 2.0.19
       memfs: 3.4.7
@@ -10306,7 +10303,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack: 5.76.0(webpack-cli@5.0.1)
-      webpack-dev-middleware: 5.3.3(webpack@5.76.0(webpack-cli@5.0.1))
+      webpack-dev-middleware: 5.3.3(webpack@5.76.0)
       ws: 8.8.0
     optionalDependencies:
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.76.0)
@@ -10380,7 +10377,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.3(webpack@5.76.0(webpack-cli@5.0.1))
+      terser-webpack-plugin: 5.3.3(webpack@5.76.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
Fixes #745

## Summary

- Replace deprecated `import ... assert` with `import ... with` in 6 rollup config files across examples (Node 22+ removed the `assert` keyword)
- Assign unique port ranges to 4 examples to prevent `EADDRINUSE` when tests run sequentially:
  - `webpack-host`: 5010/5011
  - `simple-react-systemjs`: 5020/5021
  - `basic-host-remote`: 5030/5031
  - `simple-react-webpack`: 5040/5041
- Add `waitForServer()` poll in `vitestSetup-serve.ts` and `vitestSetup-dev.ts` to avoid race condition between server startup and `page.goto()`
- Increase `beforeAll` hook timeout from 60s to 120s to accommodate slow builds + server readiness wait
- Add missing `html-webpack-plugin` dependency to `simple-react-webpack/remote`

## Test plan

- [x] `pnpm test:e2e-serve` — 11 passed, 0 failed, 1 skipped (was 6 passed, 5 failed)
- [x] `pnpm test:unit` — 46 passed (no regressions)
- [ ] CI pipeline on Node 18/20 (should also pass since `with` is supported from Node 18.20+)

## Files changed

**Import assertions → attributes (6 files):**
- `packages/examples/simple-react-systemjs/{host-systemjs,remote-systemjs}/rollup.config.mjs`
- `packages/examples/basic-host-remote/rollup-host/rollup.config.mjs`
- `packages/examples/simple-react-webpack/host/rollup.config.mjs`
- `packages/examples/simple-react-esm/{host-esm,remote-esm}/rollup.config.mjs`

**Port reassignment + portMap (18 files):**
- `packages/examples/webpack-host/` (5 files)
- `packages/examples/simple-react-systemjs/` (5 files)
- `packages/examples/basic-host-remote/` (5 files)
- `packages/examples/simple-react-webpack/` (6 files)

**Server readiness + timeout (2 files):**
- `packages/examples/vitestSetup-serve.ts`
- `packages/examples/vitestSetup-dev.ts`

**Missing dependency (1 file + lockfile):**
- `packages/examples/simple-react-webpack/remote/package.json`
- `pnpm-lock.yaml`